### PR TITLE
Create stripe event endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,8 @@ Rails.application.routes.draw do
       post "stripe/create_checkout_session"
     end
   end
+
+  namespace :stripe do
+    resources :events, only: [ :create ]
+  end
 end


### PR DESCRIPTION
Recreate the Stripe webhook endpoint that was previously created by `stripe-rails` (and removed when the gem was uninstalled)