### PR TITLE
Store ordered items into Order record

### DIFF
--- a/app/controllers/stripe/events_controller.rb
+++ b/app/controllers/stripe/events_controller.rb
@@ -36,7 +36,7 @@ class Stripe::EventsController < ApplicationController
             user = User.find_by_stripe_customer_id stripe_customer_id
         end
 
-        
+
         stripe_checkout_session = Stripe::Checkout::Session.list payment_intent: event.data.object.id
 
         if stripe_checkout_session.blank?
@@ -45,17 +45,17 @@ class Stripe::EventsController < ApplicationController
                 message: "There was an issue creating your order. Please try again later."
             }, status: 500
         end
-        
+
         checkout_line_items = Stripe::Checkout::Session.list_line_items stripe_checkout_session.first.id
-        
-        stripe_checkout_session_line_items = checkout_line_items.map {|item| {name: item.description, quantity: item.quantity}}
-        
+
+        stripe_checkout_session_line_items = checkout_line_items.map { |item| { name: item.description, quantity: item.quantity } }
+
         order = Order.new(
-            stripe_payment_intent_id: event.data.object.id, 
+            stripe_payment_intent_id: event.data.object.id,
             user: user,
             stripe_checkout_session_line_items: stripe_checkout_session_line_items
         )
-            
+
         if !order.save
             puts "There was an issue creating an order for Payment Intent# #{event.data.object.id}"
             render json: {

--- a/app/controllers/stripe/events_controller.rb
+++ b/app/controllers/stripe/events_controller.rb
@@ -32,13 +32,30 @@ class Stripe::EventsController < ApplicationController
     def payment_intent_succeeded(event)
         stripe_customer_id = event.data.object.customer
 
-
         if stripe_customer_id
             user = User.find_by_stripe_customer_id stripe_customer_id
         end
 
-        order = Order.new stripe_id: event.data.object.id, user: user
+        
+        stripe_checkout_session = Stripe::Checkout::Session.list payment_intent: event.data.object.id
 
+        if stripe_checkout_session.blank?
+            puts "No Stripe Checkout session associated with payment intent ##{event.data.object.id} - Cannot proceed since line items cannot be stored in the order."
+            render json: {
+                message: "There was an issue creating your order. Please try again later."
+            }, status: 500
+        end
+        
+        checkout_line_items = Stripe::Checkout::Session.list_line_items stripe_checkout_session.first.id
+        
+        stripe_checkout_session_line_items = checkout_line_items.map {|item| {name: item.description, quantity: item.quantity}}
+        
+        order = Order.new(
+            stripe_payment_intent_id: event.data.object.id, 
+            user: user,
+            stripe_checkout_session_line_items: stripe_checkout_session_line_items
+        )
+            
         if !order.save
             puts "There was an issue creating an order for Payment Intent# #{event.data.object.id}"
             render json: {

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -35,7 +35,7 @@ module Types
 
     field :list_products, Types::Stripe::ListObjectType, null: false
     def list_products
-      ::Stripe::Product.list
+      ::Stripe::Product.list active: true
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,7 +3,7 @@ class Order < ApplicationRecord
 
   enum :status, [ :received, :active, :in_transit, :completed ]
 
-  validates_presence_of :stripe_id
+  validates_presence_of :stripe_payment_intent_id
 
   before_create  { |order| order.status = :received }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
 
     after_initialize :ensure_recovery_password_digest, :ensure_session_token
 
+    has_many :orders
+
     def self.generate_token
         SecureRandom.urlsafe_base64 36
     end

--- a/db/migrate/20241112210452_change_column_stripe_id_to_stripe_payment_intent_id.rb
+++ b/db/migrate/20241112210452_change_column_stripe_id_to_stripe_payment_intent_id.rb
@@ -1,0 +1,5 @@
+class ChangeColumnStripeIdToStripePaymentIntentId < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :orders, :stripe_id, :stripe_payment_intent_id
+  end
+end

--- a/db/migrate/20241112210647_add_order_line_items_to_orders.rb
+++ b/db/migrate/20241112210647_add_order_line_items_to_orders.rb
@@ -1,0 +1,5 @@
+class AddOrderLineItemsToOrders < ActiveRecord::Migration[8.0]
+  def change
+    add_column :orders, :stripe_checkout_session_line_items, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_12_210452) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_12_210647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_12_210452) do
     t.string "stripe_payment_intent_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "stripe_checkout_session_line_items"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_10_223525) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_12_210452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "orders", force: :cascade do |t|
     t.bigint "user_id"
     t.integer "status", null: false
-    t.string "stripe_id", null: false
+    t.string "stripe_payment_intent_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_orders_on_user_id"

--- a/spec/cassettes/event_payment_intent_succeeded_checkout.yml
+++ b/spec/cassettes/event_payment_intent_succeeded_checkout.yml
@@ -1,0 +1,320 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/checkout/sessions?payment_intent=pi_3QKRKvElA4InVgv81SMzUj1j
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.1.1
+      Authorization:
+      - "<BEARER_TOKEN>"
+      Stripe-Version:
+      - 2024-10-28.acacia
+      X-Stripe-Client-User-Agent:
+      - "<X_STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 12 Nov 2024 21:42:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3260'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fcheckout%2Fsessions; block-all-mixed-content;
+        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_6M75djfcMaN1pt
+      Stripe-Version:
+      - 2024-10-28.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - A
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "cs_test_a1BBn4RW1sExgdMOA3yk7xvFVn2XGfONbOZsy0h6Up4CROhQKSYxcLJ49U",
+              "object": "checkout.session",
+              "adaptive_pricing": {
+                "enabled": false
+              },
+              "after_expiration": null,
+              "allow_promotion_codes": null,
+              "amount_subtotal": 300,
+              "amount_total": 300,
+              "automatic_tax": {
+                "enabled": false,
+                "liability": null,
+                "status": null
+              },
+              "billing_address_collection": "auto",
+              "cancel_url": "http://localhost:3000/order",
+              "client_reference_id": null,
+              "client_secret": null,
+              "consent": null,
+              "consent_collection": null,
+              "created": 1731445756,
+              "currency": "usd",
+              "currency_conversion": null,
+              "custom_fields": [],
+              "custom_text": {
+                "after_submit": null,
+                "shipping_address": null,
+                "submit": null,
+                "terms_of_service_acceptance": null
+              },
+              "customer": "cus_RCb5X2SQYOwAKG",
+              "customer_creation": null,
+              "customer_details": {
+                "address": {
+                  "city": "San Francisco",
+                  "country": "USA",
+                  "line1": "123 Main St",
+                  "line2": "Apt 567",
+                  "postal_code": "12355",
+                  "state": "UT"
+                },
+                "email": "dairytest@test.com",
+                "name": "Dairy Test",
+                "phone": null,
+                "tax_exempt": "none",
+                "tax_ids": []
+              },
+              "customer_email": null,
+              "expires_at": 1731532156,
+              "invoice": null,
+              "invoice_creation": {
+                "enabled": false,
+                "invoice_data": {
+                  "account_tax_ids": null,
+                  "custom_fields": null,
+                  "description": null,
+                  "footer": null,
+                  "issuer": null,
+                  "metadata": {},
+                  "rendering_options": null
+                }
+              },
+              "livemode": false,
+              "locale": null,
+              "metadata": {},
+              "mode": "payment",
+              "payment_intent": "pi_3QKRKvElA4InVgv81SMzUj1j",
+              "payment_link": null,
+              "payment_method_collection": "if_required",
+              "payment_method_configuration_details": {
+                "id": "pmc_1QKI6xElA4InVgv8AaZ4UKa9",
+                "parent": null
+              },
+              "payment_method_options": {
+                "card": {
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card",
+                "link",
+                "cashapp",
+                "amazon_pay"
+              ],
+              "payment_status": "paid",
+              "phone_number_collection": {
+                "enabled": false
+              },
+              "recovered_from": null,
+              "saved_payment_method_options": {
+                "allow_redisplay_filters": [
+                  "always"
+                ],
+                "payment_method_remove": null,
+                "payment_method_save": "enabled"
+              },
+              "setup_intent": null,
+              "shipping_address_collection": null,
+              "shipping_cost": null,
+              "shipping_details": null,
+              "shipping_options": [],
+              "status": "complete",
+              "submit_type": null,
+              "subscription": null,
+              "success_url": "http://localhost:3000/success",
+              "total_details": {
+                "amount_discount": 0,
+                "amount_shipping": 0,
+                "amount_tax": 0
+              },
+              "ui_mode": "hosted",
+              "url": null
+            }
+          ],
+          "has_more": false,
+          "url": "/v1/checkout/sessions"
+        }
+  recorded_at: Tue, 12 Nov 2024 21:42:45 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a1BBn4RW1sExgdMOA3yk7xvFVn2XGfONbOZsy0h6Up4CROhQKSYxcLJ49U/line_items
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.1.1
+      Authorization:
+      - "<BEARER_TOKEN>"
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_6M75djfcMaN1pt","request_duration_ms":261}}'
+      Stripe-Version:
+      - 2024-10-28.acacia
+      X-Stripe-Client-User-Agent:
+      - "<X_STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 12 Nov 2024 21:42:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1089'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - report-uri https://q.stripe.com/csp-report?p=v1%2Fcheckout%2Fsessions%2F%3Asession%2Fline_items;
+        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
+        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
+        style-src 'self'
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to="coop"
+      Report-To:
+      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - coop="https://q.stripe.com/coop-report"
+      Request-Id:
+      - req_d6KnCDJeI7tyNq
+      Stripe-Version:
+      - 2024-10-28.acacia
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - A
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "object": "list",
+          "data": [
+            {
+              "id": "li_1QKRKqElA4InVgv8Y7FdR1Rz",
+              "object": "item",
+              "amount_discount": 0,
+              "amount_subtotal": 300,
+              "amount_tax": 0,
+              "amount_total": 300,
+              "currency": "usd",
+              "description": "Mixed Berry Smoothie (Water base)",
+              "price": {
+                "id": "price_1QG44XElA4InVgv8dOnqfhyu",
+                "object": "price",
+                "active": true,
+                "billing_scheme": "per_unit",
+                "created": 1730403021,
+                "currency": "usd",
+                "custom_unit_amount": null,
+                "livemode": false,
+                "lookup_key": null,
+                "metadata": {},
+                "nickname": null,
+                "product": "prod_R8KkVOibvpRPlc",
+                "recurring": null,
+                "tax_behavior": "unspecified",
+                "tiers_mode": null,
+                "transform_quantity": null,
+                "type": "one_time",
+                "unit_amount": 300,
+                "unit_amount_decimal": "300"
+              },
+              "quantity": 1
+            }
+          ],
+          "has_more": false,
+          "url": "/v1/checkout/sessions/cs_test_a1BBn4RW1sExgdMOA3yk7xvFVn2XGfONbOZsy0h6Up4CROhQKSYxcLJ49U/line_items"
+        }
+  recorded_at: Tue, 12 Nov 2024 21:42:45 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/signup_feature_spec.yml
+++ b/spec/cassettes/signup_feature_spec.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/customers
     body:
       encoding: UTF-8
-      string: email=new_user_valid_params%40test.com&address[city]=San+Francisco&address[country]=USA&address[line1]=123+Main+St.&address[line2]=Suite+55&address[postal_code]=&address[state]=&name=Tester+Testington&phone=123-555-8901
+      string: email=some%40email.com&address[city]=Some+City&address[country]=Some+Country&address[line1]=Some+address&address[line2]=Some+additional+address&address[postal_code]=12345&address[state]=&name=Some+Name&phone=123-456-7890
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.1.1
@@ -31,11 +31,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 12 Nov 2024 02:48:58 GMT
+      - Tue, 12 Nov 2024 22:25:26 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '812'
+      - '813'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -60,13 +60,13 @@ http_interactions:
       Idempotency-Key:
       - "<IDEMPOTENCY_KEY>"
       Original-Request:
-      - req_RmnoO0igguZoVQ
+      - req_rvnLhwwOVydgXP
       Report-To:
       - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_RmnoO0igguZoVQ
+      - req_rvnLhwwOVydgXP
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -87,25 +87,25 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cus_RCZIJ7sFlVkgf2",
+          "id": "cus_RCsHtnIrVKu0yH",
           "object": "customer",
           "address": {
-            "city": "San Francisco",
-            "country": "USA",
-            "line1": "123 Main St.",
-            "line2": "Suite 55",
-            "postal_code": "",
+            "city": "Some City",
+            "country": "Some Country",
+            "line1": "Some address",
+            "line2": "Some additional address",
+            "postal_code": "12345",
             "state": ""
           },
           "balance": 0,
-          "created": 1731379738,
+          "created": 1731450325,
           "currency": null,
           "default_source": null,
           "delinquent": false,
           "description": null,
           "discount": null,
-          "email": "new_user_valid_params@test.com",
-          "invoice_prefix": "343C8B6B",
+          "email": "some@email.com",
+          "invoice_prefix": "00C5BEDE",
           "invoice_settings": {
             "custom_fields": null,
             "default_payment_method": null,
@@ -114,18 +114,18 @@ http_interactions:
           },
           "livemode": false,
           "metadata": {},
-          "name": "Tester Testington",
+          "name": "Some Name",
           "next_invoice_sequence": 1,
-          "phone": "123-555-8901",
+          "phone": "123-456-7890",
           "preferred_locales": [],
           "shipping": null,
           "tax_exempt": "none",
           "test_clock": null
         }
-  recorded_at: Tue, 12 Nov 2024 02:48:58 GMT
+  recorded_at: Tue, 12 Nov 2024 22:25:25 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/products
+    uri: https://api.stripe.com/v1/products?active=true
     body:
       encoding: US-ASCII
       string: ''
@@ -150,7 +150,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 12 Nov 2024 02:48:58 GMT
+      - Tue, 12 Nov 2024 22:25:26 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -181,7 +181,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_M6SJVLEvCsygGq
+      - req_Cr8LxFa7AxGoHk
       Stripe-Version:
       - 2024-10-28.acacia
       Vary:
@@ -250,5 +250,5 @@ http_interactions:
           "has_more": false,
           "url": "/v1/products"
         }
-  recorded_at: Tue, 12 Nov 2024 02:48:58 GMT
+  recorded_at: Tue, 12 Nov 2024 22:25:26 GMT
 recorded_with: VCR 6.3.1

--- a/spec/fixtures/stripe/event_payment_intent_succeeded.json
+++ b/spec/fixtures/stripe/event_payment_intent_succeeded.json
@@ -1,0 +1,64 @@
+{
+  "id": "evt_3QKRKvElA4InVgv81fQKuWwq",
+  "object": "event",
+  "api_version": "2024-10-28.acacia",
+  "created": 1731445762,
+  "data": {
+    "object": {
+      "id": "pi_3QKRKvElA4InVgv81SMzUj1j",
+      "object": "payment_intent",
+      "amount": 300,
+      "amount_capturable": 0,
+      "amount_details": { "tip": {} },
+      "amount_received": 300,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic_async",
+      "client_secret": "<REDACTED>",
+      "confirmation_method": "automatic",
+      "created": 1731445761,
+      "currency": "usd",
+      "customer": "cus_RCb5X2SQYOwAKG",
+      "description": null,
+      "invoice": null,
+      "last_payment_error": null,
+      "latest_charge": "ch_3QKRKvElA4InVgv81purNRwM",
+      "livemode": false,
+      "metadata": {},
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": "pm_1QKHpeElA4InVgv8FWy944dm",
+      "payment_method_configuration_details": null,
+      "payment_method_options": {
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": ["card"],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "succeeded",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 3,
+  "request": {
+    "id": "req_mDSi3HH25qbhG8",
+    "idempotency_key": "<REDACTED>"
+  },
+  "type": "payment_intent.succeeded"
+}

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Order, type: :model do
   context "associations" do
     it "sets a user if assigned" do
       user = create :user, :valid_user
-      order = build :order, user: user, stripe_id: "12345"
+      order = build :order, user: user, stripe_payment_intent_id: "12345"
 
       expect(order.user).to eq user
     end
@@ -12,23 +12,23 @@ RSpec.describe Order, type: :model do
 
   context "validations" do
     it "allows an Order to be created without a user" do
-      order = build :order, stripe_id: "pi_12345"
+      order = build :order, stripe_payment_intent_id: "pi_12345"
 
       expect { order.save }.to change { Order.count }.from(0).to(1)
     end
 
-    it "requires stripe_id to be present" do
+    it "requires stripe_payment_intent_id to be present" do
       order = build :order
 
       expect { order.save }.not_to change { Order.count }
 
-      expect(order.errors.full_messages).to include "Stripe can't be blank"
+      expect(order.errors.full_messages).to include "Stripe payment intent can't be blank"
     end
   end
 
   context "before the order is created" do
     it "sets the status to received" do
-      order = build :order, stripe_id: "pi_12345"
+      order = build :order, stripe_payment_intent_id: "pi_12345"
 
       expect { order.save }.to change { Order.count }.from(0).to(1)
 

--- a/spec/requests/stripe/events_spec.rb
+++ b/spec/requests/stripe/events_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Stripe::EventsController", type: :request do
           bypass_event_signature payload
 
           event = JSON.parse(payload)
-          
+
           # Use VCR for the manually pinged Stripe::Checkout::Session.list payment_intent: "pi_..."
           # Where the PI ID is used from the above json mock payment intent
           VCR.use_cassette cassette_name do
@@ -28,7 +28,7 @@ RSpec.describe "Stripe::EventsController", type: :request do
               post "/stripe/events", params: event
             }.to change { Order.count }.from(0).to(1)
           end
-          
+
           expect(Order.last.stripe_payment_intent_id).to eq event["data"]["object"]["id"]
           expect(event["data"]["object"]["customer"]).to be_present
 
@@ -39,7 +39,7 @@ RSpec.describe "Stripe::EventsController", type: :request do
           response_checkout_line_items = JSON.parse(cassette_contents["http_interactions"].last["response"]["body"]["string"], symbolize_names: true)
 
           # Ensure that the Order has its line items matching those from the
-          expected_checkout_line_items = response_checkout_line_items[:data].map {|item| {"name" => item[:description], "quantity" => item[:quantity]}}
+          expected_checkout_line_items = response_checkout_line_items[:data].map { |item| { "name" => item[:description], "quantity" => item[:quantity] } }
 
           expect(Order.last.stripe_checkout_session_line_items)
             .to eq(expected_checkout_line_items)


### PR DESCRIPTION
- Store the Stripe Checkout Session line items into a new `Order` when it's created after a successful Payment Intent 
- Update the previous `stripe_id` column to `stripe_payment_intent_id` on the `orders` table

### Other
- fetch only `active` Stripe Products on the Order page 