### PR TITLE
Fix ActiveJob::SerializationError when sending order received emails

### DIFF
--- a/app/controllers/stripe/events_controller.rb
+++ b/app/controllers/stripe/events_controller.rb
@@ -65,7 +65,7 @@ class Stripe::EventsController < ApplicationController
         OrderMailer
             .with(
                 order: order,
-                stripe_checkout_session: stripe_checkout_session.first,
+                stripe_customer_email: stripe_checkout_session.first.customer_details.email,
                 line_items: order.stripe_checkout_session_line_items
             )
             .order_received

--- a/app/controllers/stripe/events_controller.rb
+++ b/app/controllers/stripe/events_controller.rb
@@ -74,7 +74,7 @@ class Stripe::EventsController < ApplicationController
         Admin::OrderMailer
             .with(
                 order: order,
-                stripe_checkout_session: stripe_checkout_session.first,
+                stripe_customer_email: stripe_checkout_session.first.customer_details.email,
                 line_items: order.stripe_checkout_session_line_items
             )
             .order_received

--- a/app/mailers/admin/order_mailer.rb
+++ b/app/mailers/admin/order_mailer.rb
@@ -2,10 +2,10 @@ class Admin::OrderMailer < ApplicationMailer
     def order_received
         @line_items = params[:line_items]
         @order = params[:order]
-        @stripe_checkout_session = params[:stripe_checkout_session]
+        @email = params[:stripe_customer_email]
 
-        if @stripe_checkout_session.blank?
-            puts "No checkout session found for the customer"
+        if @email.blank?
+            puts "No stripe customer email found for the customer. Order#: #{@order.id}"
 
             return
         end

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -2,16 +2,16 @@ class OrderMailer < ApplicationMailer
     def order_received
         @line_items = params[:line_items]
         @order = params[:order]
-        stripe_checkout_session = params[:stripe_checkout_session]
+        email = params[:stripe_customer_email]
 
-        if stripe_checkout_session.blank?
-            puts "No checkout session found for the customer"
+        if email.blank?
+            puts "No stripe customer email found for the customer: Order##{@order.id}"
 
             return
         end
 
         mail(
-            to: stripe_checkout_session.customer_details.email,
+            to: email,
             subject: "Order received"
         )
     end

--- a/app/views/admin/order_mailer/order_received.html.erb
+++ b/app/views/admin/order_mailer/order_received.html.erb
@@ -1,7 +1,7 @@
 <h1>A User has placed an order</h1>
 <hr />
 <p>Order #<%= @order.id %></p>
-<p>Placed by: <%= @stripe_checkout_session.customer_details.email %></p>
+<p>Placed by: <%= @email %></p>
 <% if @order.user.present? %>
     <p>User id: <%= @order.user.id %></p>
 <% end %>

--- a/app/views/admin/order_mailer/order_received.text.erb
+++ b/app/views/admin/order_mailer/order_received.text.erb
@@ -2,7 +2,7 @@ A User has placed an order
 ================================================
 
 Order #<%= @order.id %>
-Placed by: <%= @stripe_checkout_session.customer_details.email %>
+Placed by: <%= @email %>
 <% if @order.user.present? %>
     User id: <%= @order.user.id %>
 <% end %>

--- a/spec/mailers/admin/order_mailer_spec.rb
+++ b/spec/mailers/admin/order_mailer_spec.rb
@@ -3,39 +3,41 @@ require "rails_helper"
 RSpec.describe Admin::OrderMailer, type: :mailer do
   let(:order) { create(:order, :with_line_items) }
 
-  it "sends an email" do
-    # Mocking Stripe::Checkout::Session without VCR
-    # since it's impossible to connect a payment intent with a session outside of the UI
-    checkout_session_mock_json = JSON.parse(
-      File.read "./spec/fixtures/stripe/stripe_checkout_session_customer_present.json",
-      symbolize_names: true
-    )
-    stripe_checkout_session = Stripe::Checkout::Session.construct_from(checkout_session_mock_json)
-    stripe_checkout_list = Stripe::ListObject.construct_from({ data: [ checkout_session_mock_json ] })
+  context "#order_received" do
+    it "sends an email" do
+      # Mocking Stripe::Checkout::Session without VCR
+      # since it's impossible to connect a payment intent with a session outside of the UI
+      checkout_session_mock_json = JSON.parse(
+        File.read "./spec/fixtures/stripe/stripe_checkout_session_customer_present.json",
+        symbolize_names: true
+      )
+      stripe_checkout_session = Stripe::Checkout::Session.construct_from(checkout_session_mock_json)
+      stripe_checkout_list = Stripe::ListObject.construct_from({ data: [ checkout_session_mock_json ] })
 
-    expect {
-      Admin::OrderMailer
-        .with(
-          order: order,
-          line_items: order.stripe_checkout_session_line_items,
-          stripe_checkout_session: stripe_checkout_session
-        )
-        .order_received
-        .deliver_now
-    }.to change { ActionMailer::Base.deliveries.length }.from(0).to(1)
+      expect {
+        Admin::OrderMailer
+          .with(
+            order: order,
+            line_items: order.stripe_checkout_session_line_items,
+            stripe_customer_email: stripe_checkout_session.customer_details.email
+          )
+          .order_received
+          .deliver_now
+      }.to change { ActionMailer::Base.deliveries.length }.from(0).to(1)
 
-    email = ActionMailer::Base.deliveries.first
+      email = ActionMailer::Base.deliveries.first
 
-    expect(email.to).to include Rails.application.credentials.dig(:admin_email)
-    expect(email.subject).to eq "An order has been placed"
+      expect(email.to).to include Rails.application.credentials.dig(:admin_email)
+      expect(email.subject).to eq "An order has been placed"
 
-    email_body = email.html_part.body.decoded
-    expect(email_body).to include "A User has placed an order"
-    expect(email_body).to include order.id.to_s
-    expect(email_body).to include stripe_checkout_session.customer_details.email
-    order.stripe_checkout_session_line_items.each do |item|
-      expect(email_body).to include item["name"]
-      expect(email_body).to include "x#{item["quantity"]}"
+      email_body = email.html_part.body.decoded
+      expect(email_body).to include "A User has placed an order"
+      expect(email_body).to include order.id.to_s
+      expect(email_body).to include stripe_checkout_session.customer_details.email
+      order.stripe_checkout_session_line_items.each do |item|
+        expect(email_body).to include item["name"]
+        expect(email_body).to include "x#{item["quantity"]}"
+      end
     end
   end
 end

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -3,34 +3,36 @@ require "rails_helper"
 RSpec.describe OrderMailer, type: :mailer do
   let(:order) { create(:order, :with_line_items) }
 
-  it "sends an email" do
-    # Mocking Stripe::Checkout::Session without VCR
-    # since it's impossible to connect a payment intent with a session outside of the UI
-    checkout_session_mock_json = JSON.parse(
-      File.read "./spec/fixtures/stripe/stripe_checkout_session_customer_present.json",
-      symbolize_names: true
-    )
-    stripe_checkout_session = Stripe::Checkout::Session.construct_from(checkout_session_mock_json)
-    stripe_checkout_list = Stripe::ListObject.construct_from({ data: [ checkout_session_mock_json ] })
+  context "#order_received" do
+    it "sends an email" do
+      # Mocking Stripe::Checkout::Session without VCR
+      # since it's impossible to connect a payment intent with a session outside of the UI
+      checkout_session_mock_json = JSON.parse(
+        File.read "./spec/fixtures/stripe/stripe_checkout_session_customer_present.json",
+        symbolize_names: true
+      )
+      stripe_checkout_session = Stripe::Checkout::Session.construct_from(checkout_session_mock_json)
+      stripe_checkout_list = Stripe::ListObject.construct_from({ data: [ checkout_session_mock_json ] })
 
-    expect {
-      OrderMailer
-        .with(
-          order: order,
-          line_items: order.stripe_checkout_session_line_items,
-          stripe_checkout_session: stripe_checkout_session
-        )
-        .order_received
-        .deliver_now
-    }.to change { ActionMailer::Base.deliveries.length }.from(0).to(1)
+      expect {
+        OrderMailer
+          .with(
+            order: order,
+            line_items: order.stripe_checkout_session_line_items,
+            stripe_customer_email: stripe_checkout_session.customer_details.email
+          )
+          .order_received
+          .deliver_now
+      }.to change { ActionMailer::Base.deliveries.length }.from(0).to(1)
 
-    email = ActionMailer::Base.deliveries.first
+      email = ActionMailer::Base.deliveries.first
 
-    expect(email.to).to include stripe_checkout_list.first.customer_details.email
-    expect(email.subject).to eq "Order received"
+      expect(email.to).to include stripe_checkout_list.first.customer_details.email
+      expect(email.subject).to eq "Order received"
 
-    email_body = email.html_part.body.decoded
-    expect(email_body).to include "Your order has been received"
-    expect(email_body).to include order.id.to_s
+      email_body = email.html_part.body.decoded
+      expect(email_body).to include "Your order has been received"
+      expect(email_body).to include order.id.to_s
+    end
   end
 end

--- a/spec/mailers/previews/admin/order_mailer_preview.rb
+++ b/spec/mailers/previews/admin/order_mailer_preview.rb
@@ -6,14 +6,14 @@ class Admin::OrderMailerPreview < ActionMailer::Preview
             symbolize_names: true
         )
 
-        stripe_checkout_session = Stripe::Checkout::Session.construct_from(checkout_session_mock_json)
+        email = Stripe::Checkout::Session.construct_from(checkout_session_mock_json).customer_details.email
         order = Order.last
         line_items = order.stripe_checkout_session_line_items
 
         Admin::OrderMailer
             .with(
                 order: order,
-                stripe_checkout_session: stripe_checkout_session,
+                stripe_customer_email: email,
                 line_items: line_items
             )
             .order_received

--- a/spec/mailers/previews/order_mailer_preview.rb
+++ b/spec/mailers/previews/order_mailer_preview.rb
@@ -6,14 +6,14 @@ class OrderMailerPreview < ActionMailer::Preview
             symbolize_names: true
         )
 
-        stripe_checkout_session = Stripe::Checkout::Session.construct_from(checkout_session_mock_json)
+        email = Stripe::Checkout::Session.construct_from(checkout_session_mock_json).customer_details.email
         order = Order.last
         line_items = order.stripe_checkout_session_line_items
 
         OrderMailer
             .with(
                 order: order,
-                stripe_checkout_session: stripe_checkout_session,
+                stripe_customer_email: email,
                 line_items: line_items
             )
             .order_received

--- a/spec/requests/stripe/events_spec.rb
+++ b/spec/requests/stripe/events_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Stripe::EventsController", type: :request do
           # Expect mailers to have been called
           expect(OrderMailer).to have_received(:with).with(
             order: order,
-            stripe_checkout_session: response_checkout_session["data"].first,
+            stripe_customer_email: response_checkout_session["data"].first["customer_details"]["email"],
             line_items: order.stripe_checkout_session_line_items
           )
           expect(mailer_double).to have_received(:order_received)

--- a/spec/requests/stripe/events_spec.rb
+++ b/spec/requests/stripe/events_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Stripe::EventsController", type: :request do
 
           expect(Admin::OrderMailer).to have_received(:with).with(
             order: order,
-            stripe_checkout_session: response_checkout_session["data"].first,
+            stripe_customer_email: response_checkout_session["data"].first["customer_details"]["email"],
             line_items: order.stripe_checkout_session_line_items
           )
           expect(mailer_double).to have_received(:order_received)


### PR DESCRIPTION
- Pass the `stripe_customer_email` argument instead of `stripe_checkout_session` 
  - There's no need to pass the entire checkout session object, since only the email is necessary for the mailers
 

ActiveJob cannot receive complex Ruby objects as an argument, furthermore there was no need to pass the entire stripe checkout session object since only the email is needed to send the email.

Error: 
```
[ActiveJob] Failed enqueuing ActionMailer::MailDeliveryJob to Async(default): ActiveJob::SerializationError (Unsupported argument type: Stripe::Checkout::Session)
```