### PR TITLE
Set guest email on order

### DIFF
--- a/app/controllers/stripe/events_controller.rb
+++ b/app/controllers/stripe/events_controller.rb
@@ -56,7 +56,8 @@ class Stripe::EventsController < ApplicationController
         order = Order.new(
             user: user,
             stripe_checkout_session_line_items: stripe_checkout_session_line_items,
-            stripe_payment_intent_id: event.data.object.id
+            stripe_payment_intent_id: event.data.object.id,
+            guest_email: user.present? ? nil : stripe_checkout_session.first.customer_details.email
         )
 
         if !order.save

--- a/app/graphql/mutations/stripe_checkout_session_create.rb
+++ b/app/graphql/mutations/stripe_checkout_session_create.rb
@@ -50,7 +50,7 @@ module Mutations
         })
 
       rescue Stripe::InvalidRequestError => e
-          puts "Stripe::InvalidRequestError: #{e.message}"
+        puts "Stripe::InvalidRequestError: #{e.message}" unless Rails.env.test?
 
           return {
             stripe_checkout_session: nil,

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -13,5 +13,6 @@ module Types
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     field :stripe_checkout_session_line_items, [ Types::OrderLineItemType ], null: false
+    field :guest_email, String, null: true
   end
 end

--- a/app/javascript/components/admin/dashboard/AdminDashboard.test.tsx
+++ b/app/javascript/components/admin/dashboard/AdminDashboard.test.tsx
@@ -14,7 +14,6 @@ import {
 } from "graphql/types";
 import { CURRENT_USER } from "components/headerNav/HeaderNav";
 import Home from "components/Home";
-import userEvent from "@testing-library/user-event";
 
 const validMocks: MockedResponse<
   FetchOrdersQuery | CurrentUserQuery | SetOrderActiveMutation,
@@ -40,6 +39,19 @@ const validMocks: MockedResponse<
               id: "1",
               email: "testuser@test.com",
             },
+            guestEmail: null,
+          },
+          {
+            id: "2",
+            status: "received",
+            stripeCheckoutSessionLineItems: [
+              {
+                name: "Shake",
+                quantity: 1,
+              },
+            ],
+            user: null,
+            guestEmail: "guestEmail@test.com",
           },
         ],
       },
@@ -119,6 +131,19 @@ const currentUserNotAdmin: MockedResponse<
               id: "1",
               email: "testuser@test.com",
             },
+            guestEmail: null,
+          },
+          {
+            id: "2",
+            status: "received",
+            stripeCheckoutSessionLineItems: [
+              {
+                name: "Shake",
+                quantity: 1,
+              },
+            ],
+            user: null,
+            guestEmail: "guest@test.com",
           },
         ],
       },
@@ -142,21 +167,23 @@ const currentUserNotAdmin: MockedResponse<
 
 describe("<AdminDashboard />", () => {
   describe("when the user is an admin", () => {
-    // it("renders without errors", async () => {
-    //   render(
-    //     <MockedProvider mocks={validMocks}>
-    //       <MemoryRouter
-    //         initialEntries={["/admin/dashboard"]}
-    //         future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-    //       >
-    //         <Routes>
-    //           <Route path="/admin/dashboard" element={<AdminDashboard />} />
-    //         </Routes>
-    //       </MemoryRouter>
-    //     </MockedProvider>
-    //   );
-    //   expect(await screen.findByText("Admin Dashboard")).toBeInTheDocument();
-    // });
+    it("renders without errors", async () => {
+      render(
+        <MockedProvider mocks={validMocks}>
+          <MemoryRouter
+            initialEntries={["/admin/dashboard"]}
+            future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+          >
+            <Routes>
+              <Route path="/admin/dashboard" element={<AdminDashboard />} />
+            </Routes>
+          </MemoryRouter>
+        </MockedProvider>
+      );
+      expect(await screen.findByText("Admin Dashboard")).toBeInTheDocument();
+      expect(screen.getAllByText("guestEmail@test.com").length).toBeTruthy();
+      expect(screen.getAllByText("testuser@test.com").length).toBeTruthy();
+    });
   });
 
   describe("when the user is not an admin", () => {

--- a/app/javascript/components/admin/dashboard/AdminDashboard.tsx
+++ b/app/javascript/components/admin/dashboard/AdminDashboard.tsx
@@ -35,6 +35,7 @@ export const FETCH_ORDERS = gql`
         id
         email
       }
+      guestEmail
     }
   }
 `;
@@ -62,7 +63,7 @@ const DesktopOrderTable: React.FC<{
         >
           <p>{order.id}</p>
           <p>{order.status}</p>
-          <p>{order.user?.email}</p>
+          <p>{order.user?.email || order.guestEmail}</p>
           <div>
             {order.stripeCheckoutSessionLineItems.map((item, i) => (
               <p key={i}>
@@ -110,7 +111,7 @@ const ResponsiveOrderTable: React.FC<{
             </div>
             <div className="mb-2">
               <p className="font-bold">Email</p>
-              <p>{order.user?.email}</p>
+              <p>{order.user?.email || order.guestEmail}</p>
             </div>
             <div className="mb-2">
               <p className="font-bold">Items</p>

--- a/app/javascript/graphql/schema.graphql
+++ b/app/javascript/graphql/schema.graphql
@@ -145,6 +145,7 @@ type Mutation {
 
 type Order {
   createdAt: ISO8601DateTime!
+  guestEmail: String
   id: ID!
   status: String!
   stripeCheckoutSessionLineItems: [OrderLineItem!]!

--- a/app/javascript/graphql/schema.json
+++ b/app/javascript/graphql/schema.json
@@ -1273,6 +1273,20 @@
               ]
             },
             {
+              "name": "guestEmail",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {

--- a/app/javascript/graphql/types.ts
+++ b/app/javascript/graphql/types.ts
@@ -152,6 +152,7 @@ export type MutationUserCreateArgs = {
 export type Order = {
   __typename?: 'Order';
   createdAt: Scalars['ISO8601DateTime']['output'];
+  guestEmail?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   status: Scalars['String']['output'];
   stripeCheckoutSessionLineItems: Array<OrderLineItem>;
@@ -360,7 +361,7 @@ export type SetOrderActiveMutation = { __typename?: 'Mutation', setOrderActive?:
 export type FetchOrdersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type FetchOrdersQuery = { __typename?: 'Query', orders?: Array<{ __typename?: 'Order', id: string, status: string, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', name: string, quantity: number }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
+export type FetchOrdersQuery = { __typename?: 'Query', orders?: Array<{ __typename?: 'Order', id: string, status: string, guestEmail?: string | null, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', name: string, quantity: number }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
 
 export type CurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -527,6 +528,7 @@ export const FetchOrdersDocument = gql`
       id
       email
     }
+    guestEmail
   }
 }
     `;

--- a/db/migrate/20241115032430_add_guest_email_to_orders.rb
+++ b/db/migrate/20241115032430_add_guest_email_to_orders.rb
@@ -1,0 +1,5 @@
+class AddGuestEmailToOrders < ActiveRecord::Migration[8.0]
+  def change
+    add_column :orders, :guest_email, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_14_205856) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_15_032430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_14_205856) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "stripe_checkout_session_line_items"
+    t.text "guest_email"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/spec/cassettes/event_payment_intent_succeeded_checkout.yml
+++ b/spec/cassettes/event_payment_intent_succeeded_checkout.yml
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 14 Nov 2024 03:07:40 GMT
+      - Fri, 15 Nov 2024 04:03:15 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -58,7 +58,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_591nQWbgngZvN0
+      - req_ywHTPPEp9bPlIr
       Stripe-Version:
       - 2024-10-28.acacia
       Vary:
@@ -197,7 +197,7 @@ http_interactions:
           "has_more": false,
           "url": "/v1/checkout/sessions"
         }
-  recorded_at: Thu, 14 Nov 2024 03:07:39 GMT
+  recorded_at: Fri, 15 Nov 2024 04:03:15 GMT
 - request:
     method: get
     uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a1BBn4RW1sExgdMOA3yk7xvFVn2XGfONbOZsy0h6Up4CROhQKSYxcLJ49U/line_items
@@ -210,7 +210,7 @@ http_interactions:
       Authorization:
       - "<BEARER_TOKEN>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_591nQWbgngZvN0","request_duration_ms":270}}'
+      - '{"last_request_metrics":{"request_id":"req_ywHTPPEp9bPlIr","request_duration_ms":284}}'
       Stripe-Version:
       - 2024-10-28.acacia
       X-Stripe-Client-User-Agent:
@@ -227,7 +227,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 14 Nov 2024 03:07:40 GMT
+      - Fri, 15 Nov 2024 04:03:15 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -259,7 +259,7 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_rIs58O8tcFLhgA
+      - req_U2FRXKGgRgv1oT
       Stripe-Version:
       - 2024-10-28.acacia
       Vary:
@@ -316,5 +316,5 @@ http_interactions:
           "has_more": false,
           "url": "/v1/checkout/sessions/cs_test_a1BBn4RW1sExgdMOA3yk7xvFVn2XGfONbOZsy0h6Up4CROhQKSYxcLJ49U/line_items"
         }
-  recorded_at: Thu, 14 Nov 2024 03:07:40 GMT
+  recorded_at: Fri, 15 Nov 2024 04:03:15 GMT
 recorded_with: VCR 6.3.1

--- a/spec/requests/stripe/events_spec.rb
+++ b/spec/requests/stripe/events_spec.rb
@@ -10,84 +10,131 @@ RSpec.describe "Stripe::EventsController", type: :request do
 
   describe "POST /stripe/events" do
     context "payment_intent.succeeded" do
-      context "when there is a customer" do
-        let(:cassette_name) { "event_payment_intent_succeeded_checkout" }
-        let(:mailer_double) { double(OrderMailer) }
-        let(:admin_mailer_double) { double(Admin::OrderMailer) }
+      let(:cassette_name) { "event_payment_intent_succeeded_checkout" }
 
-        it "creates an order" do
-          # Use a payment intent generated through the Stripe Checkout page
-          # This more accurately reflects a successful payment intent, versus creating one manually using VCR
-          payload = File.read("spec/fixtures/stripe/event_payment_intent_succeeded.json")
-          bypass_event_signature payload
+      # Using a mock payment intent succeeded event for a Stripe Checkout performed through the UI
+      # This is used to construct the event sent to the website
+      # VCR is used later to fetch the completed Stripe Checkout associated with this event
+      # and again to fetch the line items for the Stripe Checkout.
+      # If, for whatever reason, this payment intent event is deleted, just re-do a Stripe Checkout and get the event
+      let(:payload) { File.read("spec/fixtures/stripe/event_payment_intent_succeeded.json") }
 
-          event = JSON.parse(payload)
+      # This is the JSON that will be passed into the events#create route to continue the webhook response
+      let(:event) { JSON.parse(payload) }
 
-          expect(event["data"]["object"]["metadata"]["RAILS_ENV"]).to eq Rails.env
+      # The response from the cassette will be used to assert the values for events performed by our server
+      let(:cassette_contents)  { YAML.load_file("./spec/cassettes/#{cassette_name}.yml") }
 
-          # Mock mailers now for expectation later
-          allow(OrderMailer).to receive(:with) { mailer_double }
-          allow(mailer_double).to receive(:order_received) { mailer_double }
-          allow(mailer_double).to receive(:deliver_later) { mailer_double }
-
-          allow(Admin::OrderMailer).to receive(:with) { admin_mailer_double }
-          allow(admin_mailer_double).to receive(:order_received) { admin_mailer_double }
-          allow(admin_mailer_double).to receive(:deliver_later) { admin_mailer_double }
-
-          # Use VCR for the manually pinged Stripe::Checkout::Session.list payment_intent: "pi_..."
-          # Where the PI ID is used from the above json mock payment intent
-          VCR.use_cassette cassette_name do
-            expect {
-              post "/stripe/events", params: event
-            }.to change { Order.count }.from(0).to(1)
-          end
-
-          expect(Order.last.stripe_payment_intent_id).to eq event["data"]["object"]["id"]
-          expect(event["data"]["object"]["customer"]).to be_present
-
-          # Parse the cassette contents to match against the actual request
-          cassette_contents = YAML.load_file("./spec/cassettes/#{cassette_name}.yml")
-
-          # The parsed checkout from the cassette
-          response_checkout_session = Stripe::Checkout::Session.construct_from(
-            JSON.parse(
-              cassette_contents["http_interactions"].first["response"]["body"]["string"]
-            )
+      # The below variables represent the objects as they would be returned by a Stripe API call,
+      # parsed from the contents of the VCR cassette
+      let(:response_checkout_session) {
+        Stripe::Checkout::Session.construct_from(
+          JSON.parse(
+            cassette_contents["http_interactions"].first["response"]["body"]["string"]
           )
+        )
+      }
 
-          # The parsed line items from the cassette contents
-          response_checkout_line_items = JSON.parse(
-            cassette_contents["http_interactions"].last["response"]["body"]["string"],
-            symbolize_names: true
-          )
+      let(:response_checkout_line_items) {
+        JSON.parse(
+          cassette_contents["http_interactions"].last["response"]["body"]["string"],
+          symbolize_names: true
+        )
+      }
 
-          # Ensure that the Order has its line items matching those from the
-          expected_checkout_line_items = response_checkout_line_items[:data].map do |item|
-            { "name" => item[:description], "quantity" => item[:quantity] }
-          end
+      before(:each) do
+        bypass_event_signature payload
+      end
 
-          order = Order.last
+      it "sends an email to the admin user" do
+        admin_mailer_double = double(Admin::OrderMailer)
 
-          expect(order.stripe_checkout_session_line_items)
-          .to eq(expected_checkout_line_items)
+        allow(Admin::OrderMailer).to receive(:with) { admin_mailer_double }
+        allow(admin_mailer_double).to receive(:order_received) { admin_mailer_double }
+        allow(admin_mailer_double).to receive(:deliver_later) { admin_mailer_double }
 
-          # Expect mailers to have been called
-          expect(OrderMailer).to have_received(:with).with(
-            order: order,
-            stripe_customer_email: response_checkout_session["data"].first["customer_details"]["email"],
-            line_items: order.stripe_checkout_session_line_items
-          )
-          expect(mailer_double).to have_received(:order_received)
-          expect(mailer_double).to have_received(:deliver_later)
-
-          expect(Admin::OrderMailer).to have_received(:with).with(
-            order: order,
-            stripe_customer_email: response_checkout_session["data"].first["customer_details"]["email"],
-            line_items: order.stripe_checkout_session_line_items
-          )
-          expect(mailer_double).to have_received(:order_received)
-          expect(mailer_double).to have_received(:deliver_later)
+        VCR.use_cassette cassette_name do
+          expect {
+            post "/stripe/events", params: event
+          }.to change { Order.count }.from(0).to(1)
         end
+
+        order = Order.last
+
+        expect(Admin::OrderMailer).to have_received(:with).with(
+          order: order,
+          stripe_customer_email: response_checkout_session["data"].first["customer_details"]["email"],
+          line_items: order.stripe_checkout_session_line_items
+        )
+        expect(admin_mailer_double).to have_received(:order_received)
+        expect(admin_mailer_double).to have_received(:deliver_later)
+      end
+
+      it "sends an email to the customer" do
+        mailer_double = double(OrderMailer)
+
+        allow(OrderMailer).to receive(:with) { mailer_double }
+        allow(mailer_double).to receive(:order_received) { mailer_double }
+        allow(mailer_double).to receive(:deliver_later) { mailer_double }
+
+        VCR.use_cassette cassette_name do
+          expect {
+            post "/stripe/events", params: event
+          }.to change { Order.count }.from(0).to(1)
+        end
+
+        order = Order.last
+
+        expect(OrderMailer).to have_received(:with).with(
+          order: order,
+          stripe_customer_email: response_checkout_session["data"].first["customer_details"]["email"],
+          line_items: order.stripe_checkout_session_line_items
+        )
+        expect(mailer_double).to have_received(:order_received)
+        expect(mailer_double).to have_received(:deliver_later)
+      end
+
+      it "creates a order for a guest (no User registered with the stripe customer id)" do
+        expect(event["data"]["object"]["metadata"]["RAILS_ENV"]).to eq Rails.env
+
+        VCR.use_cassette cassette_name do
+          expect {
+            post "/stripe/events", params: event
+          }.to change { Order.count }.from(0).to(1)
+        end
+
+        order = Order.last
+
+        expect(order.stripe_payment_intent_id).to eq event["data"]["object"]["id"]
+        expect(event["data"]["object"]["customer"]).to be_present
+        expect(order.stripe_checkout_session_line_items)
+          .to eq(order.stripe_checkout_session_line_items)
+        expect(order.guest_email).to eq(response_checkout_session["data"].first["customer_details"]["email"])
+      end
+
+      it "creates a order for a User (User in this app has a stripe id associated before the order is created)" do
+        user = create :user, :valid_user, stripe_customer_id: event["data"]["object"]["customer"]
+
+        expect(event["data"]["object"]["metadata"]["RAILS_ENV"]).to eq Rails.env
+
+        VCR.use_cassette cassette_name do
+          expect {
+            post "/stripe/events", params: event
+          }.to change { Order.count }.from(0).to(1)
+        end
+
+        order = Order.last
+
+        expect(order.stripe_payment_intent_id).to eq event["data"]["object"]["id"]
+        expect(event["data"]["object"]["customer"]).to be_present
+        expect(order.stripe_checkout_session_line_items)
+          .to eq(order.stripe_checkout_session_line_items)
+
+        # Technically, the user email should equal that in the Stripe checkout
+        # Due to the order of the mocking, it makes sense to ensure the order points to the created user
+        # and the guest email is blank, because this ensures that the user created in this spec was assigned to the order
+        expect(order.user).to eq user
+        expect(order.guest_email).to be nil
       end
     end
   end


### PR DESCRIPTION
- Set the `guest_email` column on a new `Order` if the Stripe Checkout Customer is not a user in the app's database (I.e., a user with an existing `stripe_customer_id` prior to completing a successful checkout)

### Other
- Break up  the `events_spec` into separate tests implementing context variables to increase readability and modularity of the specs