### PR TITLE
Attempt to create Fly worker process to run bin/jobs

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,10 @@ app = 'dairy-free-food'
 primary_region = 'lax'
 console_command = '/rails/bin/rails console'
 
+[processes]
+app=""
+worker = "bin/jobs"
+
 [build]
 
 [deploy]


### PR DESCRIPTION
Config file modified to include a process to run `bin/jobs` (currently the Solid Queue DB table is setup 🥳 , but the jobs aren't being executed, only queued in the table).