### PR TITLE
Create confirm button component

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -19,4 +19,8 @@
   .blue-button {
     @apply bg-blue-700 rounded text-gray-100 font-bold py-2 px-4 cursor-pointer hover:bg-blue-500 transition-colors duration-300;
   }
+
+  .red-button {
+    @apply bg-red-700 rounded text-gray-100 font-bold py-2 px-4 cursor-pointer hover:bg-red-500 transition-colors duration-300;
+  }
 }

--- a/app/javascript/components/admin/dashboard/AdminDashboard.tsx
+++ b/app/javascript/components/admin/dashboard/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 import { gql } from "@apollo/client";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ConfirmButton from "components/confirmButton/ConfirmButton";
 import {
   FetchOrdersQuery,
   OrderStatus,
@@ -82,12 +83,12 @@ const DesktopOrderTable: React.FC<OrderTableArgs> = ({
           </div>
           <div className="justify-self-center">
             {order.status === "received" && (
-              <button
-                className="green-button"
-                onClick={() => setOrderActive(order.id)}
-              >
-                Set Active
-              </button>
+              <ConfirmButton
+                action={() => setOrderActive(order.id)}
+                actionText={`Set order #${order.id} to active?`}
+                buttonClassName="green-button"
+                buttonText="Set Active"
+              />
             )}
           </div>
         </div>
@@ -132,12 +133,12 @@ const ResponsiveOrderTable: React.FC<OrderTableArgs> = ({
             </div>
             <div>
               {order.status === "received" && (
-                <button
-                  className="green-button"
-                  onClick={() => setOrderActive(order.id)}
-                >
-                  Set Active
-                </button>
+                <ConfirmButton
+                  action={() => setOrderActive(order.id)}
+                  actionText={`Set order #${order.id} to active?`}
+                  buttonClassName="green-button"
+                  buttonText="Set Active"
+                />
               )}
             </div>
           </div>

--- a/app/javascript/components/confirmButton/ConfirmButton.test.tsx
+++ b/app/javascript/components/confirmButton/ConfirmButton.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { screen, render, waitFor } from "@testing-library/react";
+import ConfirmButton from "components/confirmButton/ConfirmButton";
+import userEvent from "@testing-library/user-event";
+
+describe("<ConfirmButton />", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("renders action and button text in the components", () => {
+    const actionText = "Complete this test on the first try";
+    const buttonText = "We Have Liftoff";
+
+    render(
+      <ConfirmButton
+        action={jest.fn()}
+        actionText={actionText}
+        buttonText={buttonText}
+      />
+    );
+
+    expect(screen.getByText(actionText)).toBeInTheDocument();
+    expect(screen.getByText(buttonText)).toBeInTheDocument();
+  });
+
+  describe("when a button classname is provided", () => {
+    it("applies it to the button", () => {
+      const buttonClassName = "super-amazing-tailwind-style";
+      const buttonText = "We Have Liftoff";
+
+      render(
+        <ConfirmButton
+          action={jest.fn()}
+          actionText="Complete this test on the first try"
+          buttonClassName={buttonClassName}
+          buttonText={buttonText}
+        />
+      );
+
+      expect(screen.getByText(buttonText)).toHaveClass(buttonClassName);
+    });
+  });
+
+  it("hides the modal by default", () => {
+    render(
+      <ConfirmButton
+        action={jest.fn()}
+        actionText="Complete this test on the first try"
+        buttonText="We Have Liftoff"
+      />
+    );
+
+    expect(screen.getByTestId("confirm-button-modal")).toHaveClass("hidden");
+  });
+
+  it("shows the modal when the button is clicked", async () => {
+    const buttonText = "We Have Liftoff";
+
+    render(
+      <ConfirmButton
+        action={jest.fn()}
+        actionText="Complete this test on the first try"
+        buttonText={buttonText}
+      />
+    );
+
+    userEvent.click(screen.getByText(buttonText));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirm-button-modal")).toHaveClass("fixed");
+    });
+  });
+
+  describe("when the 'Confirm' button is clicked", () => {
+    it("calls the action", async () => {
+      const action = jest.fn();
+
+      render(
+        <ConfirmButton
+          action={action}
+          actionText="Complete this test on the first try"
+          buttonText="We Have Liftoff"
+        />
+      );
+
+      userEvent.click(screen.getByText("Confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("confirm-button-modal")).toHaveClass(
+          "hidden"
+        );
+        expect(action).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when the 'Cancel' button is clicked", () => {
+    it("closes the modal", async () => {
+      render(
+        <ConfirmButton
+          action={jest.fn()}
+          actionText="Complete this test on the first try"
+          buttonText="We Have Liftoff"
+        />
+      );
+
+      userEvent.click(screen.getByText("Cancel"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("confirm-button-modal")).toHaveClass(
+          "hidden"
+        );
+      });
+    });
+
+    it("does not call the action", async () => {
+      const action = jest.fn();
+
+      render(
+        <ConfirmButton
+          action={action}
+          actionText="Complete this test on the first try"
+          buttonText="We Have Liftoff"
+        />
+      );
+
+      userEvent.click(screen.getByText("Cancel"));
+
+      await waitFor(() => {
+        expect(action).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/app/javascript/components/confirmButton/ConfirmButton.tsx
+++ b/app/javascript/components/confirmButton/ConfirmButton.tsx
@@ -18,9 +18,9 @@ const ConfirmButton: React.FC<{
 
   return (
     <div className="text-center select-none ">
-      <div className={buttonClassName} onClick={() => toggleShow(true)}>
-        <span>{buttonText}</span>
-      </div>
+      <button className={buttonClassName} onClick={() => toggleShow(true)}>
+        {buttonText}
+      </button>
       <div
         className={`${
           show ? "fixed" : "hidden"

--- a/app/javascript/components/confirmButton/ConfirmButton.tsx
+++ b/app/javascript/components/confirmButton/ConfirmButton.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+
+const ConfirmButton: React.FC<{
+  actionText?: string;
+  buttonText: string;
+  buttonClassName?: string;
+  action: () => void;
+}> = ({ action, buttonText, actionText, buttonClassName }) => {
+  const [show, toggleShow] = useState(false);
+
+  useEffect(() => {
+    if (show) {
+      document.body.classList.add("overflow-hidden");
+    } else {
+      document.body.classList.remove("overflow-hidden");
+    }
+  }, [show]);
+
+  return (
+    <div className="text-center select-none ">
+      <div className={buttonClassName} onClick={() => toggleShow(true)}>
+        <span>{buttonText}</span>
+      </div>
+      <div
+        className={`${
+          show ? "fixed" : "hidden"
+        } bg-gray-400/50 top-0 left-0 border-gray-200  flex justify-center items-center w-full h-full`}
+      >
+        <div className="bg-gray-700 rounded border-4 p-4 z-50">
+          <p>Please confirm that you would like to continue this action:</p>
+
+          {actionText && <p className="font-bold my-4">{actionText}</p>}
+
+          <div className="flex gap-4 justify-center">
+            <button className="green-button" onClick={action}>
+              Confirm
+            </button>
+            <button className="red-button" onClick={() => toggleShow(false)}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmButton;

--- a/app/javascript/components/confirmButton/ConfirmButton.tsx
+++ b/app/javascript/components/confirmButton/ConfirmButton.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 const ConfirmButton: React.FC<{
-  actionText?: string;
+  actionText: string;
   buttonText: string;
   buttonClassName?: string;
   action: () => void;
@@ -17,11 +17,12 @@ const ConfirmButton: React.FC<{
   }, [show]);
 
   return (
-    <div className="text-center select-none ">
+    <div className="text-center select-none">
       <button className={buttonClassName} onClick={() => toggleShow(true)}>
         {buttonText}
       </button>
       <div
+        data-testid="confirm-button-modal"
         className={`${
           show ? "fixed" : "hidden"
         } bg-gray-400/50 top-0 left-0 border-gray-200  flex justify-center items-center w-full h-full`}

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -18,6 +18,9 @@ RSpec.feature "Admin Dashboard", type: :feature do
             set_active_button = order_row.find_button("Set Active")
 
             set_active_button.click
+            expect(page).to have_button "Confirm"
+            click_button "Confirm"
+
             expect(order_row.find("p", text: "active")).to be_present
             expect(orders.first.reload.active?).to be true
         end


### PR DESCRIPTION
- Create `<ConfirmButton />` to be used in place of regular buttons requiring a confirmation before continuing the action (e.g. setting an order status)