### PR TITLE
Email upon order activated

### DIFF
--- a/app/graphql/mutations/set_order_status.rb
+++ b/app/graphql/mutations/set_order_status.rb
@@ -13,9 +13,13 @@ module Mutations
 
       raise GraphQL::ExecutionError, "The order does not exist." if order.nil?
 
-      # raise GraphQL::ExecutionError, "The order is not in the received status." if !order.received?
-
       order.update(status: set_order_status_input_type[:status])
+
+      case order.status.to_sym
+      when :active
+        OrderMailer.with(order: order).order_active.deliver_later
+      end
+
 
       order.reload
 

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -15,4 +15,21 @@ class OrderMailer < ApplicationMailer
             subject: "Order received"
         )
     end
+
+    def order_active
+        @line_items = params[:line_items]
+        @order = params[:order]
+        email = params[:email_to]
+
+        if email.blank?
+            puts "No stripe customer email found for the customer: Order##{@order.id}"
+
+            return
+        end
+
+        mail(
+            to: email,
+            subject: "Order Being Prepared"
+        )
+    end
 end

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -17,9 +17,9 @@ class OrderMailer < ApplicationMailer
     end
 
     def order_active
-        @line_items = params[:line_items]
         @order = params[:order]
-        email = params[:email_to]
+        @line_items = @order.stripe_checkout_session_line_items
+        email = @order.user.present? ? @order.user.email_address : @order.guest_email
 
         if email.blank?
             puts "No stripe customer email found for the customer: Order##{@order.id}"

--- a/app/views/order_mailer/order_active.html.erb
+++ b/app/views/order_mailer/order_active.html.erb
@@ -1,4 +1,4 @@
-<p>Order #<%= @order.id %> is now being "prepared" and will soon enter the in-transit state.</p>
+<p>Order #<%= @order.id %> is now being "prepared", aka it has been set to active.</p>
 
 <h4>Items Ordered:</h4>
 <ul>

--- a/app/views/order_mailer/order_active.html.erb
+++ b/app/views/order_mailer/order_active.html.erb
@@ -1,0 +1,11 @@
+<p>Order #<%= @order.id %> is now being "prepared" and will soon enter the in-transit state.</p>
+
+<h4>Items Ordered:</h4>
+<ul>
+    <% @line_items.map do |item| %>
+        <li><%= item["name"] %> x<%= item["quantity"] %></li>
+    <% end %>
+</ul>
+<hr />
+
+<p style="font-size: .8em;">Please note that this is only a demo, no food will actually be delivered to you &#128513;</p>

--- a/app/views/order_mailer/order_active.text.erb
+++ b/app/views/order_mailer/order_active.text.erb
@@ -1,4 +1,4 @@
-Order #<%= @order.id %> is now being "prepared" and will soon enter the in-transit state.
+Order #<%= @order.id %> is now being "prepared", aka it has been set to active.
 =======================================
 
 Items Ordered:

--- a/app/views/order_mailer/order_active.text.erb
+++ b/app/views/order_mailer/order_active.text.erb
@@ -1,0 +1,11 @@
+Order #<%= @order.id %> is now being "prepared" and will soon enter the in-transit state.
+=======================================
+
+Items Ordered:
+    
+<% @line_items.map do |item| %>
+    <%= item["name"] %> x<%= item["quantity"] %>
+<% end %>
+=======================================
+
+Please note that this is only a demo, no food will actually be delivered to you. :)

--- a/app/views/order_mailer/order_received.html.erb
+++ b/app/views/order_mailer/order_received.html.erb
@@ -1,5 +1,4 @@
 <h1>Your order has been received</h1>
-<p>Order #<%= @order.id %> has been received, and will begin processing as soon as possible.</p>
 
 <h4>Items Ordered:</h4>
 <ul>
@@ -9,4 +8,7 @@
 </ul>
 <hr />
 
-<p>Thank you for your order.</p>
+<p>If you would like, you may <%= link_to "return to the site", root_url, target: "_blank" %>, click "Admin Demo", and click "Set Active" next to the order with id <strong style="font-weight: 700"><%= @order.id %></strong>.</p>
+<p>Please note that if you login as a demo admin, the email addresses in the orders list are hidden from view just as a precaution.</p>
+
+

--- a/app/views/order_mailer/order_received.text.erb
+++ b/app/views/order_mailer/order_received.text.erb
@@ -9,4 +9,6 @@ Items Ordered:
 <% end %>
 
 ================================================
-Thank you for your order.
+If you would like, you may return to the site, click "Admin Demo", and click "Set Active" next to the order with id# <%= @order.id %>.
+
+Please note that if you login as a demo admin, the email addresses in the orders list are hidden from view just as a precaution.

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -4,12 +4,17 @@ RSpec.feature "Admin Dashboard", type: :feature do
     context "when there is an admin user logged in" do
         let!(:orders) { create_list :order, 3, :with_line_items, :with_a_user }
         let(:user) { create :user, :valid_user, admin: true }
+        let(:mailer_double) { double('OrderMailer') }
 
         before(:each) do
             feature_login_user user
         end
 
         it "allows the user to set a received order to active" do
+            expect(OrderMailer).to receive(:with).with(order: orders.first) { mailer_double }
+            expect(mailer_double).to receive(:order_active) { mailer_double }
+            expect(mailer_double).to receive(:deliver_later) { true }
+
             visit admin_dashboard_index_path
 
             expect(page).to have_content "Admin Dashboard"

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe OrderMailer, type: :mailer do
-  let(:order) { create(:order, :with_line_items) }
-
   context "#order_received" do
+    let(:order) { create(:order, :with_line_items) }
+
     it "sends an email" do
       # Mocking Stripe::Checkout::Session without VCR
       # since it's impossible to connect a payment intent with a session outside of the UI
@@ -33,6 +33,35 @@ RSpec.describe OrderMailer, type: :mailer do
       email_body = email.html_part.body.decoded
       expect(email_body).to include "Your order has been received"
       expect(email_body).to include order.id.to_s
+    end
+  end
+
+  context "#order_active" do
+    let(:order) { create :order, :with_line_items, guest_email: Faker::Internet.email }
+
+    it "sends an email" do
+      expect {
+        OrderMailer
+          .with(
+            order: order,
+            line_items: order.stripe_checkout_session_line_items,
+            email_to: order.guest_email
+          )
+          .order_active
+          .deliver_now
+      }.to change { ActionMailer::Base.deliveries.length }.from(0).to(1)
+
+      email = ActionMailer::Base.deliveries.first
+
+      expect(email.to).to include order.guest_email
+      expect(email.subject).to eq "Order Being Prepared"
+
+      email_body = email.html_part.body.decoded
+      
+      expect(email_body).to include "Order ##{order.id} is now being \"prepared\" and will soon enter the in-transit state."
+      order.stripe_checkout_session_line_items.each do |item| 
+        expect(email_body).to include "#{item['name']} x#{item['quantity']}" 
+      end
     end
   end
 end

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -42,11 +42,7 @@ RSpec.describe OrderMailer, type: :mailer do
     it "sends an email" do
       expect {
         OrderMailer
-          .with(
-            order: order,
-            line_items: order.stripe_checkout_session_line_items,
-            email_to: order.guest_email
-          )
+          .with(order: order)
           .order_active
           .deliver_now
       }.to change { ActionMailer::Base.deliveries.length }.from(0).to(1)

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe OrderMailer, type: :mailer do
 
       email_body = email.html_part.body.decoded
 
-      expect(email_body).to include "Order ##{order.id} is now being \"prepared\" and will soon enter the in-transit state."
+      expect(email_body).to include "Order ##{order.id} is now being \"prepared\", aka it has been set to active."
       order.stripe_checkout_session_line_items.each do |item|
         expect(email_body).to include "#{item['name']} x#{item['quantity']}"
       end

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -53,10 +53,10 @@ RSpec.describe OrderMailer, type: :mailer do
       expect(email.subject).to eq "Order Being Prepared"
 
       email_body = email.html_part.body.decoded
-      
+
       expect(email_body).to include "Order ##{order.id} is now being \"prepared\" and will soon enter the in-transit state."
-      order.stripe_checkout_session_line_items.each do |item| 
-        expect(email_body).to include "#{item['name']} x#{item['quantity']}" 
+      order.stripe_checkout_session_line_items.each do |item|
+        expect(email_body).to include "#{item['name']} x#{item['quantity']}"
       end
     end
   end

--- a/spec/mailers/previews/order_mailer_preview.rb
+++ b/spec/mailers/previews/order_mailer_preview.rb
@@ -18,4 +18,23 @@ class OrderMailerPreview < ActionMailer::Preview
             )
             .order_received
     end
+
+    def order_active
+        checkout_session_mock_json = JSON.parse(
+            File.read "./spec/fixtures/stripe/stripe_checkout_session_customer_present.json",
+            symbolize_names: true
+        )
+
+        email = Stripe::Checkout::Session.construct_from(checkout_session_mock_json).customer_details.email
+        order = Order.last
+        line_items = order.stripe_checkout_session_line_items
+
+        OrderMailer
+            .with(
+                order: order,
+                email_to: email,
+                line_items: line_items
+            )
+            .order_active
+    end
 end


### PR DESCRIPTION
- Send an email to the email associated with the order after it has been set to "active" (I.e. `order.user.email_address` if present, otherwise `order.guest_email`
- Add instructions to the `order_received` action of the `OrderMailer` for logging in as a demo admin and setting the order to "active"