### PR TITLE
Set Order In-Transit

### DIFF
--- a/app/graphql/mutations/set_order_status.rb
+++ b/app/graphql/mutations/set_order_status.rb
@@ -18,6 +18,8 @@ module Mutations
       case order.status.to_sym
       when :active
         OrderMailer.with(order: order).order_active.deliver_later
+      when :in_transit
+        OrderMailer.with(order: order).order_in_transit.deliver_later
       end
 
 

--- a/app/javascript/components/admin/dashboard/AdminDashboard.test.tsx
+++ b/app/javascript/components/admin/dashboard/AdminDashboard.test.tsx
@@ -2,24 +2,14 @@ import React from "react";
 import { screen, render } from "@testing-library/react";
 import AdminDashboard, {
   FETCH_ORDERS,
-  SET_ORDER_STATUS,
 } from "components/admin/dashboard/AdminDashboard";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import {
-  CurrentUserQuery,
-  FetchOrdersQuery,
-  OrderStatus,
-  SetOrderStatusMutation,
-  SetOrderStatusMutationVariables,
-} from "graphql/types";
+import { CurrentUserQuery, FetchOrdersQuery, OrderStatus } from "graphql/types";
 import { CURRENT_USER } from "components/headerNav/HeaderNav";
 import Home from "components/Home";
 
-const validMocks: MockedResponse<
-  FetchOrdersQuery | CurrentUserQuery | SetOrderStatusMutation,
-  SetOrderStatusMutationVariables
->[] = [
+const validMocks: MockedResponse<FetchOrdersQuery | CurrentUserQuery>[] = [
   {
     maxUsageCount: 2,
     request: {
@@ -73,23 +63,7 @@ const validMocks: MockedResponse<
       },
     },
   },
-  {
-    request: {
-      query: SET_ORDER_STATUS,
-      variables: {
-        input: {
-          setOrderStatusInputType: { id: "1", status: OrderStatus.Active },
-        },
-      },
-    },
-    result: {
-      data: {
-        setOrderStatus: {
-          order: { id: "1", status: OrderStatus.Active },
-        },
-      },
-    },
-  },
+
   {
     request: {
       query: FETCH_ORDERS,

--- a/app/javascript/components/admin/dashboard/AdminDashboard.tsx
+++ b/app/javascript/components/admin/dashboard/AdminDashboard.tsx
@@ -11,6 +11,7 @@ import {
   useFetchOrdersQuery,
   useSetOrderStatusMutation,
 } from "graphql/types";
+import { startCase } from "lodash";
 import React, { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
@@ -84,7 +85,7 @@ const DesktopOrderTable: React.FC<OrderTableArgs> = ({
                 {order.id}
               </Link>
             </p>
-            <p>{order.status}</p>
+            <p>{startCase(order.status)}</p>
             <p>{order.user?.email || order.guestEmail}</p>
             <div>
               {order.stripeCheckoutSessionLineItems.map((item, i) => (
@@ -142,7 +143,7 @@ const ResponsiveOrderTable: React.FC<OrderTableArgs> = ({
             </div>
             <div className="mb-2">
               <p className="font-bold">Status</p>
-              <p>{order.status}</p>
+              <p>{startCase(order.status)}</p>
             </div>
             <div className="mb-2">
               <p className="font-bold">Email</p>

--- a/app/javascript/components/admin/dashboard/AdminDashboard.tsx
+++ b/app/javascript/components/admin/dashboard/AdminDashboard.tsx
@@ -71,10 +71,7 @@ const DesktopOrderTable: React.FC<OrderTableArgs> = ({
         <p className="font-bold">Items</p>
         <p></p>
       </div>
-      <div
-        // key={order.id}
-        className="grid grid-cols-[50px_100px_1fr_1fr_125px] gap-4 items-center"
-      >
+      <div className="grid grid-cols-[50px_100px_1fr_1fr_125px] gap-4 items-center">
         {orders.map((order) => (
           <React.Fragment key={order.id}>
             <p>

--- a/app/javascript/components/admin/dashboard/AdminDashboard.tsx
+++ b/app/javascript/components/admin/dashboard/AdminDashboard.tsx
@@ -48,11 +48,15 @@ type OrderTableArgs = {
   setOrderActive: (
     id: SetOrderStatusInput["setOrderStatusInputType"]["id"]
   ) => void;
+  setOrderInTransit: (
+    id: SetOrderStatusInput["setOrderStatusInputType"]["id"]
+  ) => void;
 };
 
 const DesktopOrderTable: React.FC<OrderTableArgs> = ({
   orders,
   setOrderActive,
+  setOrderInTransit,
 }) => {
   if (!orders) return null;
 
@@ -66,40 +70,50 @@ const DesktopOrderTable: React.FC<OrderTableArgs> = ({
         <p className="font-bold">Items</p>
         <p></p>
       </div>
-      {orders.map((order) => (
-        <div
-          key={order.id}
-          className="grid grid-cols-[50px_100px_1fr_1fr_125px] gap-4"
-        >
-          <p>
-            <Link
-              to={`/admin/orders/${order.id}`}
-              className="text-blue-400 hover:underline"
-            >
-              {order.id}
-            </Link>
-          </p>
-          <p>{order.status}</p>
-          <p>{order.user?.email || order.guestEmail}</p>
-          <div>
-            {order.stripeCheckoutSessionLineItems.map((item, i) => (
-              <p key={i}>
-                {item.name} x{item.quantity}
-              </p>
-            ))}
-          </div>
-          <div className="justify-self-center">
-            {order.status === "received" && (
-              <ConfirmButton
-                action={() => setOrderActive(order.id)}
-                actionText={`Set order #${order.id} to active?`}
-                buttonClassName="green-button"
-                buttonText="Set Active"
-              />
-            )}
-          </div>
-        </div>
-      ))}
+      <div
+        // key={order.id}
+        className="grid grid-cols-[50px_100px_1fr_1fr_125px] gap-4 items-center"
+      >
+        {orders.map((order) => (
+          <React.Fragment key={order.id}>
+            <p>
+              <Link
+                to={`/admin/orders/${order.id}`}
+                className="text-blue-400 hover:underline"
+              >
+                {order.id}
+              </Link>
+            </p>
+            <p>{order.status}</p>
+            <p>{order.user?.email || order.guestEmail}</p>
+            <div>
+              {order.stripeCheckoutSessionLineItems.map((item, i) => (
+                <p key={i}>
+                  {item.name} x{item.quantity}
+                </p>
+              ))}
+            </div>
+            <div className="justify-self-center">
+              {order.status === OrderStatus.Received && (
+                <ConfirmButton
+                  action={() => setOrderActive(order.id)}
+                  actionText={`Set order #${order.id} to active?`}
+                  buttonClassName="green-button"
+                  buttonText="Set Active"
+                />
+              )}
+              {order.status === OrderStatus.Active && (
+                <ConfirmButton
+                  action={() => setOrderInTransit(order.id)}
+                  actionText={`Set order #${order.id} to in-transit?`}
+                  buttonClassName="green-button"
+                  buttonText="Set In-Transit"
+                />
+              )}
+            </div>
+          </React.Fragment>
+        ))}
+      </div>
     </div>
   );
 };
@@ -107,6 +121,7 @@ const DesktopOrderTable: React.FC<OrderTableArgs> = ({
 const ResponsiveOrderTable: React.FC<OrderTableArgs> = ({
   orders,
   setOrderActive,
+  setOrderInTransit,
 }) => {
   if (!orders) return null;
 
@@ -144,12 +159,20 @@ const ResponsiveOrderTable: React.FC<OrderTableArgs> = ({
               </div>
             </div>
             <div>
-              {order.status === "received" && (
+              {order.status === OrderStatus.Received && (
                 <ConfirmButton
                   action={() => setOrderActive(order.id)}
                   actionText={`Set order #${order.id} to active?`}
                   buttonClassName="green-button"
                   buttonText="Set Active"
+                />
+              )}
+              {order.status === OrderStatus.Active && (
+                <ConfirmButton
+                  action={() => setOrderInTransit(order.id)}
+                  actionText={`Set order #${order.id} to in-transit?`}
+                  buttonClassName="green-button"
+                  buttonText="Set In-Transit"
                 />
               )}
             </div>
@@ -160,7 +183,7 @@ const ResponsiveOrderTable: React.FC<OrderTableArgs> = ({
   );
 };
 
-const setOrderActiveVariables = (
+const setOrderStatusVariables = (
   id: SetOrderStatusMutationVariables["input"]["setOrderStatusInputType"]["id"],
   status: SetOrderStatusMutationVariables["input"]["setOrderStatusInputType"]["status"]
 ): SetOrderStatusMutationVariables => {
@@ -193,7 +216,15 @@ const AdminDashboard = () => {
     id: SetOrderStatusInput["setOrderStatusInputType"]["id"]
   ) => {
     setOrderStatus({
-      variables: setOrderActiveVariables(id, OrderStatus.Active),
+      variables: setOrderStatusVariables(id, OrderStatus.Active),
+    });
+  };
+
+  const setOrderInTransit = (
+    id: SetOrderStatusInput["setOrderStatusInputType"]["id"]
+  ) => {
+    setOrderStatus({
+      variables: setOrderStatusVariables(id, OrderStatus.InTransit),
     });
   };
 
@@ -230,10 +261,12 @@ const AdminDashboard = () => {
               <DesktopOrderTable
                 orders={ordersData.orders}
                 setOrderActive={setOrderActive}
+                setOrderInTransit={setOrderInTransit}
               />
               <ResponsiveOrderTable
                 orders={ordersData.orders}
                 setOrderActive={setOrderActive}
+                setOrderInTransit={setOrderInTransit}
               />
             </>
           )}

--- a/app/javascript/components/confirmButton/ConfirmButton.tsx
+++ b/app/javascript/components/confirmButton/ConfirmButton.tsx
@@ -18,7 +18,10 @@ const ConfirmButton: React.FC<{
 
   return (
     <div className="text-center select-none">
-      <button className={buttonClassName} onClick={() => toggleShow(true)}>
+      <button
+        className={`${buttonClassName} whitespace-pre`}
+        onClick={() => toggleShow(true)}
+      >
         {buttonText}
       </button>
       <div

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -10,10 +10,7 @@ class OrderMailer < ApplicationMailer
             return
         end
 
-        mail(
-            to: email,
-            subject: "Order received"
-        )
+        mail to: email, subject: "Order received"
     end
 
     def order_active
@@ -27,9 +24,20 @@ class OrderMailer < ApplicationMailer
             return
         end
 
-        mail(
-            to: email,
-            subject: "Order Being Prepared"
-        )
+        mail to: email, subject: "Order Being Prepared"
+    end
+
+    def order_in_transit
+        @order = params[:order]
+        @line_items = @order.stripe_checkout_session_line_items
+        email = @order.user.present? ? @order.user.email_address : @order.guest_email
+
+        if email.blank?
+            puts "No stripe customer email found for the customer: Order##{@order.id}"
+
+            return
+        end
+
+        mail to: email, subject: "Order In-Transit!"
     end
 end

--- a/app/views/order_mailer/order_active.html.erb
+++ b/app/views/order_mailer/order_active.html.erb
@@ -8,4 +8,6 @@
 </ul>
 <hr />
 
+<p>You may, if you'd like to, of course, <%= link_to "return back to the Admin Dashboard", admin_dashboard_index_url %> to set the order to "In Transit" to continue with the demo!
+
 <p style="font-size: .8em;">Please note that this is only a demo, no food will actually be delivered to you &#128513;</p>

--- a/app/views/order_mailer/order_active.text.erb
+++ b/app/views/order_mailer/order_active.text.erb
@@ -8,4 +8,6 @@ Items Ordered:
 <% end %>
 =======================================
 
+You may, if you'd like to, of course, return back to the Admin Dashboard to set the order to "In Transit" to continue with the demo!
+
 Please note that this is only a demo, no food will actually be delivered to you. :)

--- a/app/views/order_mailer/order_in_transit.html.erb
+++ b/app/views/order_mailer/order_in_transit.html.erb
@@ -1,0 +1,13 @@
+<p>Order #<%= @order.id %> is now "In Transit"! &#129395; </p>
+
+<p style="font-size: 10px">Unfortunately, it isn't coming anytime soon -- but if you're reading this, chances are you already know this. I really am planning on doing this one day for reals, though &128513;</p>
+
+<h4>Items Being Delivered:</h4>
+<ul>
+    <% @line_items.map do |item| %>
+        <li><%= item["name"] %> x<%= item["quantity"] %></li>
+    <% end %>
+</ul>
+<hr />
+
+<p>Finally, you may <%= link_to "return to the Admin Dashboard", admin_dashboard_index_url %> to set the order to "Completed"!

--- a/app/views/order_mailer/order_in_transit.html.erb
+++ b/app/views/order_mailer/order_in_transit.html.erb
@@ -1,8 +1,8 @@
 <p>Order #<%= @order.id %> is now "In Transit"! &#129395; </p>
 
-<p style="font-size: 10px">Unfortunately, it isn't coming anytime soon -- but if you're reading this, chances are you already know this. I really am planning on doing this one day for reals, though &128513;</p>
+<p style="font-size: 10px">Unfortunately, it isn't coming anytime soon -- but if you're reading this, chances are you already know this. I really am planning on doing this one day for reals, though  &#128513; </p>
 
-<h4>Items Being Delivered:</h4>
+<h4>Items Being "Delivered":</h4>
 <ul>
     <% @line_items.map do |item| %>
         <li><%= item["name"] %> x<%= item["quantity"] %></li>

--- a/app/views/order_mailer/order_in_transit.text.erb
+++ b/app/views/order_mailer/order_in_transit.text.erb
@@ -1,0 +1,14 @@
+Order #<%= @order.id %> is now "In Transit"! 
+=======================================
+
+Unfortunately, it isn't coming anytime soon -- but if you're reading this, chances are you already know this. I really am planning on doing this one day for reals, though :)</p>
+
+Items Being "Delivered":
+
+<% @line_items.map do |item| %>
+    <%= item["name"] %> x<%= item["quantity"] %>
+<% end %>
+
+=======================================
+
+Finally, you may return to the Admin Dashboard to set the order to "Complete"!

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -2,16 +2,17 @@ require 'rails_helper'
 
 RSpec.feature "Admin Dashboard", type: :feature do
     context "when there is an admin user logged in" do
-        let!(:orders) { create_list :order, 3, :with_line_items, :with_a_user }
         let(:user) { create :user, :valid_user, admin: true }
-        let(:mailer_double) { double('OrderMailer') }
+        let(:mailer_double) { double(OrderMailer) }
 
         before(:each) do
             feature_login_user user
         end
 
         it "allows the user to set a received order to active" do
-            expect(OrderMailer).to receive(:with).with(order: orders.first) { mailer_double }
+            order = create :order, :with_line_items, :with_a_user
+
+            expect(OrderMailer).to receive(:with).with(order: order) { mailer_double }
             expect(mailer_double).to receive(:order_active) { mailer_double }
             expect(mailer_double).to receive(:deliver_later) { true }
 
@@ -19,15 +20,31 @@ RSpec.feature "Admin Dashboard", type: :feature do
 
             expect(page).to have_content "Admin Dashboard"
 
-            order_row = find("p", text: orders.first.user.email_address).find(:xpath, "./..")
-            set_active_button = order_row.find_button("Set Active")
-
-            set_active_button.click
+            click_button "Set Active"
             expect(page).to have_button "Confirm"
             click_button "Confirm"
 
-            expect(order_row.find("p", text: "active")).to be_present
-            expect(orders.first.reload.active?).to be true
+            expect(page).to have_content "Active"
+            expect(order.reload.active?).to be true
+        end
+
+        it "allows the user to set a received order to in_transit" do
+            order = create :order, :with_line_items, :with_a_user, :active
+
+            expect(OrderMailer).to receive(:with).with(order: order) { mailer_double }
+            expect(mailer_double).to receive(:order_in_transit) { mailer_double }
+            expect(mailer_double).to receive(:deliver_later) { true }
+
+            visit admin_dashboard_index_path
+
+            expect(page).to have_content "Admin Dashboard"
+
+            click_button "Set In-Transit"
+            expect(page).to have_button "Confirm"
+            click_button "Confirm"
+
+            expect(page).to have_content "In Transit"
+            expect(order.reload.in_transit?).to be true
         end
     end
 end

--- a/spec/mailers/previews/order_mailer_preview.rb
+++ b/spec/mailers/previews/order_mailer_preview.rb
@@ -30,11 +30,22 @@ class OrderMailerPreview < ActionMailer::Preview
         line_items = order.stripe_checkout_session_line_items
 
         OrderMailer
-            .with(
-                order: order,
-                email_to: email,
-                line_items: line_items
-            )
+            .with(order: order)
             .order_active
+    end
+
+    def order_in_transit
+        checkout_session_mock_json = JSON.parse(
+            File.read "./spec/fixtures/stripe/stripe_checkout_session_customer_present.json",
+            symbolize_names: true
+        )
+
+        email = Stripe::Checkout::Session.construct_from(checkout_session_mock_json).customer_details.email
+        order = Order.last
+        line_items = order.stripe_checkout_session_line_items
+
+        OrderMailer
+            .with(order: order)
+            .order_in_transit
     end
 end

--- a/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
+++ b/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
@@ -68,6 +68,9 @@ RSpec.describe "Set Order Status Mutation Spec" do
       end
 
       context "when the order is set to active" do
+         let(:order) { create :order, :with_a_user, :with_line_items }
+         let(:mailer_double) { double('OrderMailer') }
+
          def perform_query(order)
             expect {
                post graphql_path, params: {
@@ -85,8 +88,6 @@ RSpec.describe "Set Order Status Mutation Spec" do
          end
 
          it "sets the order status" do
-            order = create :order, :with_line_items
-
             perform_query order
 
             graphql_response = JSON.parse(response.body)
@@ -96,17 +97,51 @@ RSpec.describe "Set Order Status Mutation Spec" do
             expect(graphql_order["status"]).to eq order.status
          end
 
-         context "when the order has a user" do
-            let(:order) { create :order, :with_a_user, :with_line_items }
-            let(:mailer_double) { double('OrderMailer') }
+         it "sends an email to the user's email address" do
+            expect(OrderMailer).to receive(:with).with(order: order) { mailer_double }
+            expect(mailer_double).to receive(:order_active) { mailer_double }
+            expect(mailer_double).to receive(:deliver_later) { true }
 
-            it "sends an email to the user's email address" do
-               expect(OrderMailer).to receive(:with).with(order: order) { mailer_double }
-               expect(mailer_double).to receive(:order_active) { mailer_double }
-               expect(mailer_double).to receive(:deliver_later) { true }
+            perform_query order
+         end
+      end
 
-               perform_query order
-            end
+      context "when the order is set to in-transit" do
+         let(:order) { create :order, :with_line_items, :active }
+         let(:mailer_double) { double(OrderMailer) }
+         
+         def perform_query(order)
+            expect {
+               post graphql_path, params: {
+                  query: query,
+                  variables: {
+                     input: {
+                        setOrderStatusInputType: {
+                           id: order.id,
+                           status: "in_transit"
+                        }
+                     }
+                  }
+               }
+            }.to change { order.reload.status }.from("active").to("in_transit")
+         end
+
+         it "sets the order status" do
+            perform_query order
+
+            graphql_response = JSON.parse(response.body)
+
+            graphql_order = graphql_response["data"]["setOrderStatus"]["order"]
+            expect(graphql_order["id"].to_i).to eq order.id
+            expect(graphql_order["status"]).to eq order.status
+         end
+
+         it "sends an email" do
+            expect(OrderMailer).to receive(:with).with(order: order) { mailer_double }
+            expect(mailer_double).to receive(:order_in_transit) { mailer_double }
+            expect(mailer_double).to receive(:deliver_later) { true }
+
+            perform_query order
          end
       end
    end

--- a/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
+++ b/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "Set Order Status Mutation Spec" do
       context "when the order is set to in-transit" do
          let(:order) { create :order, :with_line_items, :active }
          let(:mailer_double) { double(OrderMailer) }
-         
+
          def perform_query(order)
             expect {
                post graphql_path, params: {


### PR DESCRIPTION
- Allow admin to set an Active order to In-Transit from the Admin Dashboard
- Cleanup the desktop admin dashboard order list css
- Add a suggestion to the order received/active email templates to become a demo admin and continue setting order statuses
- Set order statuses to a human readable string on the Admin Dashboard page