### PR TITLE
Investigate header rerenders

### DIFF
--- a/app/javascript/components/admin/dashboard/orders/AdminDashboardOrders.test.tsx
+++ b/app/javascript/components/admin/dashboard/orders/AdminDashboardOrders.test.tsx
@@ -103,10 +103,7 @@ describe("<AdminDashboardOrders />", () => {
           <Routes>
             <Route path="admin">
               <Route path="dashboard" element={<AdminDashboard />}>
-                <Route
-                  path="orders"
-                  element={<AdminDashboardOrders currentUserId="1" />}
-                />
+                <Route path="orders" element={<AdminDashboardOrders />} />
               </Route>
             </Route>
           </Routes>

--- a/app/javascript/components/admin/dashboard/orders/AdminDashboardOrders.tsx
+++ b/app/javascript/components/admin/dashboard/orders/AdminDashboardOrders.tsx
@@ -6,6 +6,7 @@ import {
   OrderStatus,
   SetOrderStatusInput,
   SetOrderStatusMutationVariables,
+  useCurrentUserQuery,
   useFetchOrdersQuery,
   useSetOrderStatusMutation,
 } from "graphql/types";
@@ -211,7 +212,8 @@ const setOrderStatusVariables = (
   };
 };
 
-const AdminDashboardOrders = ({ currentUserId }: { currentUserId: string }) => {
+const AdminDashboardOrders = () => {
+  const { data: currentUserData } = useCurrentUserQuery();
   const [
     setOrderStatus,
     {
@@ -254,7 +256,7 @@ const AdminDashboardOrders = ({ currentUserId }: { currentUserId: string }) => {
     // for the demo admin, refetch orders when the current user changes
     // this avoids using stale cache data
     refetchOrders();
-  }, [currentUserId]);
+  }, [currentUserData?.currentUser?.id]);
   return (
     <div className=" grid place-content-center">
       {ordersLoading || setOrderActiveLoading ? (

--- a/app/javascript/components/headerNav/headerNotifications/HeaderNotifications.tsx
+++ b/app/javascript/components/headerNav/headerNotifications/HeaderNotifications.tsx
@@ -145,10 +145,6 @@ const HeaderNotifications = () => {
     },
   });
 
-  // TODO: Discover why this is re-rendering so many times
-  // one reason is when the timeout expires and the component dismounts
-  // console.log("notification", data);
-
   const notificationListContainer = useRef<HTMLDivElement>(null);
   const toggleNotificationListIcon = useRef<SVGSVGElement>(null);
 

--- a/app/javascript/components/orderChatPanels/orderChat/OrderChat.tsx
+++ b/app/javascript/components/orderChatPanels/orderChat/OrderChat.tsx
@@ -180,6 +180,11 @@ const OrderChat = ({
         id="chat"
         ref={chatRef}
         className={`p-4 overflow-auto h-96 animate-slide-up`}
+        onAnimationStart={() => {
+          if (chatRef.current) {
+            chatRef.current.scrollTop = chatRef.current.scrollHeight;
+          }
+        }}
       >
         <p className="text-center text-xs bg-gray-800 rounded p-2 mb-4">
           This chat will be available after an order is received and until it is

--- a/app/javascript/routes/index.tsx
+++ b/app/javascript/routes/index.tsx
@@ -17,7 +17,6 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import AdminDashboardOrderChats from "components/admin/dashboard/orderChats/AdminDashboardOrderChats";
 
 const AppRoute = () => {
-  const { data, loading } = useCurrentUserQuery();
   return (
     <Router
       future={{
@@ -36,14 +35,7 @@ const AppRoute = () => {
             <Route path="dashboard" element={<AdminDashboard />}>
               <Route index element={<AdminDashboardIndex />} />
               <Route path="orders">
-                <Route
-                  index
-                  element={
-                    <AdminDashboardOrders
-                      currentUserId={data?.currentUser?.id || ""}
-                    />
-                  }
-                />
+                <Route index element={<AdminDashboardOrders />} />
                 <Route path=":id" element={<AdminDashboardOrder />} />
               </Route>
               <Route


### PR DESCRIPTION
Break down logout and admin demo buttons into separate components to reduce the amount of `<HeaderNav />` renders.

There are still 3 renders total, with the current user lazy query being the main culprit. Ideally, will find a way to set the current user to the Apollo cache upon login to avoid having to check the current user on each render. i.e., login will write the authenticated user to the cache so that any other queries to current user will be pulled from the cache, rather than requiring a refetch.