### PR TITLE
User orders ** RAKE **

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,4 +1,7 @@
 class OrdersController < ApplicationController
+    def index
+    end
+
     def show
     end
 end

--- a/app/controllers/stripe/events_controller.rb
+++ b/app/controllers/stripe/events_controller.rb
@@ -50,9 +50,13 @@ class Stripe::EventsController < ApplicationController
             }, status: 500
         end
 
-        checkout_line_items = Stripe::Checkout::Session.list_line_items stripe_checkout_session.first.id
+        checkout_line_items = Stripe::Checkout::Session.list_line_items stripe_checkout_session.first.id, expand: [ "data.price.product" ]
 
-        stripe_checkout_session_line_items = checkout_line_items.map { |item| { name: item.description, quantity: item.quantity } }
+        stripe_checkout_session_line_items = checkout_line_items.map do |item|
+            { name: item.description,
+            quantity: item.quantity,
+            image_url: item.price.product.images.first }
+        end
 
         order = Order.new(
             user: user,

--- a/app/controllers/stripe/events_controller.rb
+++ b/app/controllers/stripe/events_controller.rb
@@ -53,12 +53,16 @@ class Stripe::EventsController < ApplicationController
         checkout_line_items = Stripe::Checkout::Session.list_line_items stripe_checkout_session.first.id, expand: [ "data.price.product" ]
 
         stripe_checkout_session_line_items = checkout_line_items.map do |item|
-            { name: item.description,
-            quantity: item.quantity,
-            image_url: item.price.product.images.first }
+            {
+                name: item.description,
+                quantity: item.quantity,
+                image_url: item.price.product.images.first,
+                unit_amount: item.amount_total
+            }
         end
 
         order = Order.new(
+            amount_total: stripe_checkout_session.first.amount_total,
             user: user,
             stripe_checkout_session_line_items: stripe_checkout_session_line_items,
             stripe_payment_intent_id: event.data.object.id,

--- a/app/graphql/mutations/set_order_status.rb
+++ b/app/graphql/mutations/set_order_status.rb
@@ -21,6 +21,7 @@ module Mutations
       when :in_transit
         OrderMailer.with(order: order).order_in_transit.deliver_later
       when :completed
+        order.update(completed_at: Time.now)
         OrderMailer.with(order: order).order_completed.deliver_later
       end
 

--- a/app/graphql/resolvers/current_user_orders_resolver.rb
+++ b/app/graphql/resolvers/current_user_orders_resolver.rb
@@ -1,22 +1,21 @@
 class Resolvers::CurrentUserOrdersResolver < Resolvers::BaseResolver
     type [ Types::OrderType ], null: true
 
-    argument :completed, Boolean, required: true
+    argument :incomplete, Boolean, required: false
 
-    def resolve(completed:)
+    def resolve(incomplete: false)
         current_user = context[:current_user]
 
-        return nil if !current_user.present?
+        raise GraphQL::ExecutionError, "A current user is not logged in." if !current_user.present?
 
-        if completed
+        if incomplete
             Order
                 .where(user_id: current_user.id)
-                .completed
+                .where.not(status: :complete)
                 .order(created_at: :desc)
         else
             Order
                 .where(user_id: current_user.id)
-                .where.not(status: :completed)
                 .order(created_at: :desc)
         end
     end

--- a/app/graphql/resolvers/current_user_orders_resolver.rb
+++ b/app/graphql/resolvers/current_user_orders_resolver.rb
@@ -11,7 +11,7 @@ class Resolvers::CurrentUserOrdersResolver < Resolvers::BaseResolver
         if incomplete
             Order
                 .where(user_id: current_user.id)
-                .where.not(status: :complete)
+                .where.not(status: :completed)
                 .order(created_at: :desc)
         else
             Order

--- a/app/graphql/types/order_line_item_type.rb
+++ b/app/graphql/types/order_line_item_type.rb
@@ -4,6 +4,6 @@ module Types
   class OrderLineItemType < Types::BaseObject
     field :name, String, null: false
     field :quantity, Integer, null: false
-    field :image_url, String, null: true
+    field :image_url, String, null: false
   end
 end

--- a/app/graphql/types/order_line_item_type.rb
+++ b/app/graphql/types/order_line_item_type.rb
@@ -5,5 +5,6 @@ module Types
     field :name, String, null: false
     field :quantity, Integer, null: false
     field :image_url, String, null: false
+    field :unit_amount, Integer, null: false
   end
 end

--- a/app/graphql/types/order_line_item_type.rb
+++ b/app/graphql/types/order_line_item_type.rb
@@ -4,5 +4,6 @@ module Types
   class OrderLineItemType < Types::BaseObject
     field :name, String, null: false
     field :quantity, Integer, null: false
+    field :image_url, String, null: true
   end
 end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -42,5 +42,7 @@ module Types
         object.guest_email
       end
     end
+
+    field :amount_total, Integer, null: false
   end
 end

--- a/app/graphql/types/order_type.rb
+++ b/app/graphql/types/order_type.rb
@@ -3,6 +3,14 @@
 module Types
   class OrderType < Types::BaseObject
     field :id, ID, null: false
+
+    field :completed_at, String, null: true
+    def completed_at
+      return nil if object.completed_at.nil?
+
+      object.completed_at.strftime "%Y-%m-%d"
+    end
+
     field :user, Types::UserType
 
     field :status, Types::OrderStatus, null: false

--- a/app/javascript/components/headerNav/userAccountNav/UserAccountNav.test.tsx
+++ b/app/javascript/components/headerNav/userAccountNav/UserAccountNav.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import UserAccountNav from "components/headerNav/userAccountNav/UserAccountNav";
+import { MemoryRouter } from "react-router";
+
+describe("<UserAccountNav />", () => {
+  describe("with a current user email", () => {
+    const currentUserEmail = "testemail@test.com";
+
+    it("renders without errors", () => {
+      render(
+        <MemoryRouter>
+          <UserAccountNav currentUserEmail={currentUserEmail} />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText(currentUserEmail)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Logout/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("without a current user email", () => {
+    it("renders without errors", () => {
+      render(
+        <MemoryRouter>
+          <UserAccountNav currentUserEmail={null} />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByRole("link", { name: /Login/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /Signup/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/app/javascript/components/headerNav/userAccountNav/UserAccountNav.tsx
+++ b/app/javascript/components/headerNav/userAccountNav/UserAccountNav.tsx
@@ -1,15 +1,10 @@
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import client from "apolloClient";
-import {
-  CurrentUserQuery,
-  CurrentUserQueryResult,
-  Maybe,
-  User,
-} from "graphql/types";
+import { Maybe, User } from "graphql/types";
 import { useAdminLogin, useLogout } from "hooks/auth";
 import React from "react";
-import { NavLink } from "react-router";
+import { Link } from "react-router";
 
 const AdminDemoButton = () => {
   const [
@@ -47,7 +42,7 @@ const LogoutButton = () => {
   ) : (
     <button
       className="
-            py-2 px-4 blue-button transition-colors rounded font-bold
+            py-2 px-4 red-button transition-colors rounded font-bold
             "
       onClick={handleLogout}
     >
@@ -68,7 +63,9 @@ const UserAccountNav: React.FC<{
     >
       {currentUserEmail ? (
         <>
-          <NavLink to="my_orders">My Orders</NavLink>
+          <Link className="blue-button text-center" to="my_orders">
+            My Orders
+          </Link>
           <div className="text-sm mb-2 text-center">
             <p>Logged in as:</p>
             <p className="font-bold">{currentUserEmail}</p>
@@ -77,22 +74,22 @@ const UserAccountNav: React.FC<{
         </>
       ) : (
         <>
-          <NavLink
+          <Link
             className={`
               blue-button block text-center 
               `}
             to="/login"
           >
             Login
-          </NavLink>
-          <NavLink
+          </Link>
+          <Link
             className={`
               blue-button block text-center 
               `}
             to="/signup"
           >
             Signup
-          </NavLink>
+          </Link>
           <AdminDemoButton />
         </>
       )}

--- a/app/javascript/components/headerNav/userAccountNav/UserAccountNav.tsx
+++ b/app/javascript/components/headerNav/userAccountNav/UserAccountNav.tsx
@@ -68,6 +68,7 @@ const UserAccountNav: React.FC<{
     >
       {currentUserEmail ? (
         <>
+          <NavLink to="my_orders">My Orders</NavLink>
           <div className="text-sm mb-2 text-center">
             <p>Logged in as:</p>
             <p className="font-bold">{currentUserEmail}</p>

--- a/app/javascript/components/home/Home.tsx
+++ b/app/javascript/components/home/Home.tsx
@@ -14,8 +14,6 @@ const Home = () => {
         </div>
       </div>
 
-      <h3>heyo!</h3>
-
       <div className="dark-blue-background rounded p-6 lg:col-start-1 lg:col-span-2 md:row-start-2">
         <h5 className="text-lg font-bold text-center mb-4 border-b-2 pb-2">
           How to Demo <FontAwesomeIcon className="ml-2" icon={faCheck} />

--- a/app/javascript/components/home/Home.tsx
+++ b/app/javascript/components/home/Home.tsx
@@ -14,6 +14,8 @@ const Home = () => {
         </div>
       </div>
 
+      <h3>heyo!</h3>
+
       <div className="dark-blue-background rounded p-6 lg:col-start-1 lg:col-span-2 md:row-start-2">
         <h5 className="text-lg font-bold text-center mb-4 border-b-2 pb-2">
           How to Demo <FontAwesomeIcon className="ml-2" icon={faCheck} />

--- a/app/javascript/components/myOrders/MyOrders.test.tsx
+++ b/app/javascript/components/myOrders/MyOrders.test.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import MyOrders from "components/myOrders/MyOrders";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { FetchCurrentUserOrdersQuery, OrderStatus } from "graphql/types";
+import { FETCH_CURRENT_USER_ORDERS } from "components/orderChatPanels/OrderChatPanels";
+import { MemoryRouter } from "react-router";
+
+const incompleteOrder = {
+  id: "1",
+  amountTotal: 600,
+  createdAt: "2024-12-1",
+  guestEmail: null,
+  updatedAt: "2024-12-5",
+  status: OrderStatus.Received,
+  completedAt: null,
+  stripeCheckoutSessionLineItems: [
+    {
+      imageUrl: "www.someimage.com",
+      name: "Super Tasy Sando",
+      quantity: 1,
+      unitAmount: 147,
+    },
+  ],
+  user: {
+    id: "1",
+    email: "userwithincompleteorders@somewhere.com",
+  },
+};
+
+const withIncompleteOrdersMocks: MockedResponse<FetchCurrentUserOrdersQuery>[] =
+  [
+    {
+      request: { query: FETCH_CURRENT_USER_ORDERS },
+      result: {
+        data: {
+          currentUserOrders: [incompleteOrder],
+        },
+      },
+    },
+  ];
+
+const completedOrder = {
+  id: "1",
+  amountTotal: 600,
+  createdAt: "2024-12-1",
+  guestEmail: null,
+  updatedAt: "2024-12-5",
+  status: OrderStatus.Completed,
+  completedAt: "2024-12-7",
+  stripeCheckoutSessionLineItems: [
+    {
+      imageUrl: "www.someimage.com",
+      name: "Super Tasy Sando",
+      quantity: 1,
+      unitAmount: 147,
+    },
+  ],
+  user: {
+    id: "1",
+    email: "userwithincompleteorders@somewhere.com",
+  },
+};
+
+const withCompleteOrderMocks: MockedResponse<FetchCurrentUserOrdersQuery>[] = [
+  {
+    request: { query: FETCH_CURRENT_USER_ORDERS },
+    result: {
+      data: {
+        currentUserOrders: [completedOrder],
+      },
+    },
+  },
+];
+
+const withNoOrdersMocks: MockedResponse<FetchCurrentUserOrdersQuery>[] = [
+  {
+    request: { query: FETCH_CURRENT_USER_ORDERS },
+    result: {
+      data: {
+        currentUserOrders: [],
+      },
+    },
+  },
+];
+
+describe("<MyOrders />", () => {
+  describe("when there are incomplete orders", () => {
+    it("renders without errors", async () => {
+      render(
+        <MockedProvider mocks={withIncompleteOrdersMocks}>
+          <MyOrders />
+        </MockedProvider>
+      );
+
+      expect(await screen.findByText(/My Orders/i)).toBeInTheDocument();
+      expect(screen.getByText(incompleteOrder.createdAt)).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          `1 Item - ${new Intl.NumberFormat("en-EN", {
+            style: "currency",
+            currency: "USD",
+            minimumFractionDigits: 2,
+          }).format(Number((incompleteOrder.amountTotal / 100).toFixed(2)))}`
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when there is a completed order", () => {
+    it("renders without errors", async () => {
+      render(
+        <MockedProvider mocks={withCompleteOrderMocks}>
+          <MyOrders />
+        </MockedProvider>
+      );
+
+      expect(await screen.findByText(/My Orders/i)).toBeInTheDocument();
+      expect(screen.getByText(/Completed on:/i)).toBeInTheDocument();
+      expect(screen.getByText(completedOrder.completedAt)).toBeInTheDocument();
+    });
+  });
+
+  describe("when the user has no orders", () => {
+    it("renders without errors", async () => {
+      render(
+        <MockedProvider mocks={withNoOrdersMocks}>
+          <MemoryRouter>
+            <MyOrders />
+          </MemoryRouter>
+        </MockedProvider>
+      );
+
+      expect(await screen.findByText(/My Orders/i)).toBeInTheDocument();
+      expect(
+        screen.getByText((element) =>
+          element.includes("You currently have no current or past orders!")
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /Order Page/i })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/app/javascript/components/myOrders/MyOrders.tsx
+++ b/app/javascript/components/myOrders/MyOrders.tsx
@@ -7,10 +7,9 @@ import React from "react";
 const MyOrders = () => {
   const { data, loading, error } = useFetchCurrentUserOrdersQuery();
 
-  if (!data) return null;
-
   return (
     <div>
+      <h3>My Orders</h3>
       {loading ? (
         <FontAwesomeIcon icon={faSpinner} />
       ) : (

--- a/app/javascript/components/myOrders/MyOrders.tsx
+++ b/app/javascript/components/myOrders/MyOrders.tsx
@@ -52,15 +52,16 @@ const MyOrders = () => {
                   ))}
                 </div>
                 <div className="text-sm">
+                  <p className="font-bold">Order #{order.id}</p>
                   <div className="grid md:block">
                     {order.status === "completed" ? (
                       <>
-                        <p className="font-bold">Completed on:</p>
+                        <p>Completed on:</p>
                         <p>{order.completedAt}</p>
                       </>
                     ) : (
                       <>
-                        <p className="font-bold">Placed on:</p>
+                        <p>Placed on:</p>
                         <p>{order.createdAt}</p>
                         <p className="italic">{startCase(order.status)}</p>
                       </>

--- a/app/javascript/components/myOrders/MyOrders.tsx
+++ b/app/javascript/components/myOrders/MyOrders.tsx
@@ -1,6 +1,7 @@
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useFetchCurrentUserOrdersQuery } from "graphql/types";
+import { startCase } from "lodash";
 import React from "react";
 
 const MyOrders = () => {
@@ -14,24 +15,76 @@ const MyOrders = () => {
         <FontAwesomeIcon icon={faSpinner} />
       ) : (
         <div>
-          {data?.currentUserOrders?.map((order) => (
-            <div key={order.id}>
-              {order.status !== "completed" ? (
-                <p>Time placed: {order.createdAt}</p>
-              ) : (
-                <p>Time completed: {order.updatedAt}</p>
-              )}
-              <p>{order.status}</p>
-              <div>
-                {order.stripeCheckoutSessionLineItems.map((item, i) => (
-                  <div key={i}>
-                    <p>{item.name}</p>
-                    <p>{item.quantity}</p>
+          {data?.currentUserOrders?.map((order) => {
+            const items = order.stripeCheckoutSessionLineItems;
+            return (
+              <div
+                className="grid grid-cols-[auto_1fr_auto] gap-4 items-center mb-4"
+                key={order.id}
+              >
+                <div
+                  className={`justify-center`}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `repeat(${items.length * 2}, 1fr)`,
+                  }}
+                >
+                  {items.map((item, i) => (
+                    <div
+                      key={i}
+                      onMouseOver={(e) => (e.currentTarget.style.zIndex = "50")}
+                      onMouseOut={(e) =>
+                        (e.currentTarget.style.zIndex = `${items.length - i}`)
+                      }
+                      className={`w-12 h-12 hover:scale-125 transition-transform`}
+                      style={{
+                        gridArea: `1 / ${items.length * 2 + 1} / 1 / ${
+                          items.length + 1 - i
+                        }`,
+                        zIndex: items.length - i,
+                      }}
+                    >
+                      <img
+                        className={`w-full h-full rounded-full `}
+                        src={item.imageUrl}
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div className="text-sm">
+                  <div className="grid md:block">
+                    {order.status === "completed" ? (
+                      <>
+                        <p className="font-bold">Completed on:</p>
+                        <p>{order.completedAt}</p>
+                      </>
+                    ) : (
+                      <>
+                        <p className="font-bold">Placed on:</p>
+                        <p>{order.createdAt}</p>
+                        <p className="italic">{startCase(order.status)}</p>
+                      </>
+                    )}
                   </div>
-                ))}
+                  <p>
+                    {order.stripeCheckoutSessionLineItems.length} Item
+                    {order.stripeCheckoutSessionLineItems.length > 1
+                      ? "s"
+                      : ""}{" "}
+                    -{" "}
+                    {new Intl.NumberFormat("en-EN", {
+                      style: "currency",
+                      currency: "USD",
+                      minimumFractionDigits: 2,
+                    }).format(Number((order.amountTotal / 100).toFixed(2)))}
+                  </p>
+                </div>
+                <div>
+                  <button className="blue-button text-sm">View</button>
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/app/javascript/components/myOrders/MyOrders.tsx
+++ b/app/javascript/components/myOrders/MyOrders.tsx
@@ -16,6 +16,11 @@ const MyOrders = () => {
         <div>
           {data?.currentUserOrders?.map((order) => (
             <div key={order.id}>
+              {order.status !== "completed" ? (
+                <p>Time placed: {order.createdAt}</p>
+              ) : (
+                <p>Time completed: {order.updatedAt}</p>
+              )}
               <p>{order.status}</p>
               <div>
                 {order.stripeCheckoutSessionLineItems.map((item, i) => (

--- a/app/javascript/components/myOrders/MyOrders.tsx
+++ b/app/javascript/components/myOrders/MyOrders.tsx
@@ -79,9 +79,6 @@ const MyOrders = () => {
                     }).format(Number((order.amountTotal / 100).toFixed(2)))}
                   </p>
                 </div>
-                <div>
-                  <button className="blue-button text-sm">View</button>
-                </div>
               </div>
             );
           })}

--- a/app/javascript/components/myOrders/MyOrders.tsx
+++ b/app/javascript/components/myOrders/MyOrders.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const MyOrders = () => {
+  return (
+    <div>
+      <p>hey</p>
+    </div>
+  );
+};
+
+export default MyOrders;

--- a/app/javascript/components/myOrders/MyOrders.tsx
+++ b/app/javascript/components/myOrders/MyOrders.tsx
@@ -3,85 +3,110 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useFetchCurrentUserOrdersQuery } from "graphql/types";
 import { startCase } from "lodash";
 import React from "react";
+import { Link } from "react-router";
 
 const MyOrders = () => {
   const { data, loading, error } = useFetchCurrentUserOrdersQuery();
 
+  if (error) return <p>There was an error.</p>;
+
   return (
     <div>
-      <h3>My Orders</h3>
+      <h3 className="animate-home-title-shimmer font-bold text-center mb-10 text-2xl">
+        My Orders
+      </h3>
       {loading ? (
-        <FontAwesomeIcon icon={faSpinner} />
+        <div>
+          <FontAwesomeIcon
+            icon={faSpinner}
+            spin
+            className="text-2xl text-center"
+          />
+        </div>
       ) : (
         <div>
-          {data?.currentUserOrders?.map((order) => {
-            const items = order.stripeCheckoutSessionLineItems;
-            return (
-              <div
-                className="grid grid-cols-[auto_1fr_auto] gap-4 items-center mb-4"
-                key={order.id}
-              >
+          {data?.currentUserOrders?.length === 0 ? (
+            <div>
+              <p>
+                You currently have no current or past orders! Head over to the{" "}
+                <Link className="site-link" to="/order">
+                  Order Page
+                </Link>{" "}
+                to place an order!
+              </p>
+            </div>
+          ) : (
+            data?.currentUserOrders?.map((order) => {
+              const items = order.stripeCheckoutSessionLineItems;
+              return (
                 <div
-                  className={`justify-center`}
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: `repeat(${items.length * 2}, 1fr)`,
-                  }}
+                  className="grid grid-cols-[auto_1fr_auto] gap-4 items-center mb-4"
+                  key={order.id}
                 >
-                  {items.map((item, i) => (
-                    <div
-                      key={i}
-                      onMouseOver={(e) => (e.currentTarget.style.zIndex = "50")}
-                      onMouseOut={(e) =>
-                        (e.currentTarget.style.zIndex = `${items.length - i}`)
-                      }
-                      className={`w-12 h-12 hover:scale-125 transition-transform`}
-                      style={{
-                        gridArea: `1 / ${items.length * 2 + 1} / 1 / ${
-                          items.length + 1 - i
-                        }`,
-                        zIndex: items.length - i,
-                      }}
-                    >
-                      <img
-                        className={`w-full h-full rounded-full `}
-                        src={item.imageUrl}
-                      />
-                    </div>
-                  ))}
-                </div>
-                <div className="text-sm">
-                  <p className="font-bold">Order #{order.id}</p>
-                  <div className="grid md:block">
-                    {order.status === "completed" ? (
-                      <>
-                        <p>Completed on:</p>
-                        <p>{order.completedAt}</p>
-                      </>
-                    ) : (
-                      <>
-                        <p>Placed on:</p>
-                        <p>{order.createdAt}</p>
-                        <p className="italic">{startCase(order.status)}</p>
-                      </>
-                    )}
+                  <div
+                    className={`justify-center`}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: `repeat(${items.length * 2}, 1fr)`,
+                    }}
+                  >
+                    {items.map((item, i) => (
+                      <div
+                        key={i}
+                        onMouseOver={(e) =>
+                          (e.currentTarget.style.zIndex = "50")
+                        }
+                        onMouseOut={(e) =>
+                          (e.currentTarget.style.zIndex = `${items.length - i}`)
+                        }
+                        className={`w-12 h-12 hover:scale-125 transition-transform`}
+                        style={{
+                          gridArea: `1 / ${items.length * 2 + 1} / 1 / ${
+                            items.length + 1 - i
+                          }`,
+                          zIndex: items.length - i,
+                        }}
+                      >
+                        <img
+                          className={`w-full h-full rounded-full `}
+                          src={item.imageUrl}
+                        />
+                      </div>
+                    ))}
                   </div>
-                  <p>
-                    {order.stripeCheckoutSessionLineItems.length} Item
-                    {order.stripeCheckoutSessionLineItems.length > 1
-                      ? "s"
-                      : ""}{" "}
-                    -{" "}
-                    {new Intl.NumberFormat("en-EN", {
-                      style: "currency",
-                      currency: "USD",
-                      minimumFractionDigits: 2,
-                    }).format(Number((order.amountTotal / 100).toFixed(2)))}
-                  </p>
+                  <div className="text-sm">
+                    <p className="font-bold">Order #{order.id}</p>
+                    <div className="grid md:block">
+                      {order.status === "completed" ? (
+                        <>
+                          <p>Completed on:</p>
+                          <p>{order.completedAt}</p>
+                        </>
+                      ) : (
+                        <>
+                          <p>Placed on:</p>
+                          <p>{order.createdAt}</p>
+                          <p className="italic">{startCase(order.status)}</p>
+                        </>
+                      )}
+                    </div>
+                    <p>
+                      {order.stripeCheckoutSessionLineItems.length} Item
+                      {order.stripeCheckoutSessionLineItems.length > 1
+                        ? "s"
+                        : ""}{" "}
+                      -{" "}
+                      {new Intl.NumberFormat("en-EN", {
+                        style: "currency",
+                        currency: "USD",
+                        minimumFractionDigits: 2,
+                      }).format(Number((order.amountTotal / 100).toFixed(2)))}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            );
-          })}
+              );
+            })
+          )}
         </div>
       )}
     </div>

--- a/app/javascript/components/myOrders/MyOrders.tsx
+++ b/app/javascript/components/myOrders/MyOrders.tsx
@@ -1,9 +1,34 @@
+import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useFetchCurrentUserOrdersQuery } from "graphql/types";
 import React from "react";
 
 const MyOrders = () => {
+  const { data, loading, error } = useFetchCurrentUserOrdersQuery();
+
+  if (!data) return null;
+
   return (
     <div>
-      <p>hey</p>
+      {loading ? (
+        <FontAwesomeIcon icon={faSpinner} />
+      ) : (
+        <div>
+          {data?.currentUserOrders?.map((order) => (
+            <div key={order.id}>
+              <p>{order.status}</p>
+              <div>
+                {order.stripeCheckoutSessionLineItems.map((item, i) => (
+                  <div key={i}>
+                    <p>{item.name}</p>
+                    <p>{item.quantity}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/javascript/components/orderChatPanels/OrderChatPanels.test.tsx
+++ b/app/javascript/components/orderChatPanels/OrderChatPanels.test.tsx
@@ -40,7 +40,7 @@ const validMocks: MockedResponse<
   {
     request: {
       query: FETCH_CURRENT_USER_ORDERS,
-      variables: { completed: false },
+      variables: { incomplete: true },
     },
     result: {
       data: {
@@ -48,12 +48,18 @@ const validMocks: MockedResponse<
           {
             id: "1",
             status: OrderStatus.InTransit,
+            createdAt: "2024-12-6",
+            updatedAt: "2024-12-7",
+            completedAt: null,
             stripeCheckoutSessionLineItems: [
               {
                 name: "product",
                 quantity: 1,
+                imageUrl: "www.someimage.com",
+                unitAmount: 300,
               },
             ],
+            amountTotal: 600,
             user: {
               id: "1",
               email: "test@demo.com",

--- a/app/javascript/components/orderChatPanels/OrderChatPanels.tsx
+++ b/app/javascript/components/orderChatPanels/OrderChatPanels.tsx
@@ -40,6 +40,7 @@ export const FETCH_CURRENT_USER_ORDERS = gql`
       guestEmail
       updatedAt
       status
+      completedAt
       stripeCheckoutSessionLineItems {
         name
         quantity

--- a/app/javascript/components/orderChatPanels/OrderChatPanels.tsx
+++ b/app/javascript/components/orderChatPanels/OrderChatPanels.tsx
@@ -33,8 +33,8 @@ export const CREATE_ORDER_MESSAGE = gql`
 `;
 
 export const FETCH_CURRENT_USER_ORDERS = gql`
-  query FetchCurrentUserOrders($completed: Boolean!) {
-    currentUserOrders(completed: $completed) {
+  query FetchCurrentUserOrders($incomplete: Boolean) {
+    currentUserOrders(incomplete: $incomplete) {
       id
       status
       stripeCheckoutSessionLineItems {
@@ -55,7 +55,7 @@ const OrderChatPanels = () => {
     useCurrentUserQuery();
 
   const { data, loading, refetch } = useFetchCurrentUserOrdersQuery({
-    variables: { completed: false },
+    variables: { incomplete: true },
   });
 
   useEffect(() => {

--- a/app/javascript/components/orderChatPanels/OrderChatPanels.tsx
+++ b/app/javascript/components/orderChatPanels/OrderChatPanels.tsx
@@ -36,15 +36,17 @@ export const FETCH_CURRENT_USER_ORDERS = gql`
   query FetchCurrentUserOrders($incomplete: Boolean) {
     currentUserOrders(incomplete: $incomplete) {
       id
+      amountTotal
       createdAt
       guestEmail
       updatedAt
       status
       completedAt
       stripeCheckoutSessionLineItems {
+        imageUrl
         name
         quantity
-        imageUrl
+        unitAmount
       }
       user {
         id

--- a/app/javascript/components/orderChatPanels/OrderChatPanels.tsx
+++ b/app/javascript/components/orderChatPanels/OrderChatPanels.tsx
@@ -36,16 +36,19 @@ export const FETCH_CURRENT_USER_ORDERS = gql`
   query FetchCurrentUserOrders($incomplete: Boolean) {
     currentUserOrders(incomplete: $incomplete) {
       id
+      createdAt
+      guestEmail
+      updatedAt
       status
       stripeCheckoutSessionLineItems {
         name
         quantity
+        imageUrl
       }
       user {
         id
         email
       }
-      guestEmail
     }
   }
 `;

--- a/app/javascript/graphql/schema.graphql
+++ b/app/javascript/graphql/schema.graphql
@@ -229,7 +229,7 @@ type Order {
 }
 
 type OrderLineItem {
-  imageUrl: String
+  imageUrl: String!
   name: String!
   quantity: Int!
 }

--- a/app/javascript/graphql/schema.graphql
+++ b/app/javascript/graphql/schema.graphql
@@ -218,6 +218,7 @@ type NotificationEdge {
 }
 
 type Order {
+  completedAt: String
   createdAt: String!
   guestEmail: String
   id: ID!

--- a/app/javascript/graphql/schema.graphql
+++ b/app/javascript/graphql/schema.graphql
@@ -218,6 +218,7 @@ type NotificationEdge {
 }
 
 type Order {
+  amountTotal: Int!
   completedAt: String
   createdAt: String!
   guestEmail: String
@@ -233,6 +234,7 @@ type OrderLineItem {
   imageUrl: String!
   name: String!
   quantity: Int!
+  unitAmount: Int!
 }
 
 type OrderMessage {

--- a/app/javascript/graphql/schema.graphql
+++ b/app/javascript/graphql/schema.graphql
@@ -229,6 +229,7 @@ type Order {
 }
 
 type OrderLineItem {
+  imageUrl: String
   name: String!
   quantity: Int!
 }

--- a/app/javascript/graphql/schema.graphql
+++ b/app/javascript/graphql/schema.graphql
@@ -373,7 +373,7 @@ type Query {
     """
     last: Int
   ): NotificationConnection!
-  currentUserOrders(completed: Boolean!): [Order!]
+  currentUserOrders(incomplete: Boolean): [Order!]
   fetchCheckoutSession(id: ID!): CheckoutSession
   listProducts: ProductListObject!
   order(id: ID!): Order

--- a/app/javascript/graphql/schema.json
+++ b/app/javascript/graphql/schema.json
@@ -1543,9 +1543,13 @@
               "name": "imageUrl",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/app/javascript/graphql/schema.json
+++ b/app/javascript/graphql/schema.json
@@ -1401,6 +1401,18 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "completedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "createdAt",
               "description": null,
               "type": {

--- a/app/javascript/graphql/schema.json
+++ b/app/javascript/graphql/schema.json
@@ -15,9 +15,7 @@
           "kind": "OBJECT",
           "name": "AutomaticTax",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -34,9 +32,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "liability",
@@ -48,9 +44,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "status",
@@ -62,9 +56,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -84,9 +76,7 @@
           "kind": "OBJECT",
           "name": "CheckoutSession",
           "description": "Based on https://docs.stripe.com/api/checkout/sessions/object",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -99,9 +89,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "amountTotal",
@@ -113,9 +101,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "automaticTax",
@@ -131,9 +117,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "billingAddressCollection",
@@ -145,9 +129,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "cancelUrl",
@@ -159,9 +141,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "clientReferenceId",
@@ -173,9 +153,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "created",
@@ -191,9 +169,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "currency",
@@ -205,9 +181,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "customer",
@@ -219,9 +193,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "customerDetails",
@@ -233,9 +205,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "customerEmail",
@@ -247,9 +217,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "id",
@@ -265,9 +233,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "lineItems",
@@ -283,9 +249,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "livemode",
@@ -301,9 +265,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "locale",
@@ -315,9 +277,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "metadata",
@@ -329,9 +289,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "mode",
@@ -347,9 +305,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "paymentIntent",
@@ -361,9 +317,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "paymentMethodCollection",
@@ -375,9 +329,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "paymentMethodTypes",
@@ -401,9 +353,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "paymentStatus",
@@ -419,9 +369,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripeObject",
@@ -437,9 +385,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "successUrl",
@@ -455,9 +401,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "totalDetails",
@@ -473,9 +417,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "url",
@@ -491,9 +433,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -542,9 +482,7 @@
           "kind": "OBJECT",
           "name": "CreateOrderMessagePayload",
           "description": "Autogenerated return type of CreateOrderMessage.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -557,9 +495,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "errors",
@@ -575,9 +511,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "orderMessage",
@@ -589,9 +523,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -601,9 +533,7 @@
           "kind": "OBJECT",
           "name": "CurrentUserNotificationReceivedPayload",
           "description": "Autogenerated return type of CurrentUserNotificationReceived.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -616,9 +546,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -628,9 +556,7 @@
           "kind": "OBJECT",
           "name": "CustomerAddress",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -643,9 +569,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "country",
@@ -657,9 +581,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "line1",
@@ -671,9 +593,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "line2",
@@ -685,9 +605,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "postalCode",
@@ -699,9 +617,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "state",
@@ -713,9 +629,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -725,9 +639,7 @@
           "kind": "OBJECT",
           "name": "CustomerDetails",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -740,9 +652,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "email",
@@ -754,9 +664,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "name",
@@ -768,9 +676,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "phone",
@@ -782,9 +688,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "taxExempt",
@@ -796,9 +700,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "taxIds",
@@ -818,9 +720,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -853,9 +753,7 @@
           "kind": "OBJECT",
           "name": "DemoAdminSessionCreatePayload",
           "description": "Autogenerated return type of DemoAdminSessionCreate.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -868,9 +766,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "errors",
@@ -894,9 +790,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "user",
@@ -908,9 +802,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -920,9 +812,7 @@
           "kind": "OBJECT",
           "name": "Error",
           "description": "Generic error type",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -939,9 +829,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "path",
@@ -961,9 +849,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -1013,9 +899,7 @@
           "kind": "OBJECT",
           "name": "LineItem",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -1032,9 +916,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "description",
@@ -1050,9 +932,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "id",
@@ -1068,9 +948,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "quantity",
@@ -1086,9 +964,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripeObject",
@@ -1104,9 +980,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -1116,9 +990,7 @@
           "kind": "OBJECT",
           "name": "LineItemListObject",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -1139,9 +1011,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "hasMore",
@@ -1157,9 +1027,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripeObject",
@@ -1175,9 +1043,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "url",
@@ -1193,9 +1059,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -1205,9 +1069,7 @@
           "kind": "OBJECT",
           "name": "Mutation",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -1334,9 +1196,7 @@
           "kind": "OBJECT",
           "name": "Notification",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -1353,9 +1213,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "id",
@@ -1371,9 +1229,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "message",
@@ -1389,9 +1245,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "path",
@@ -1403,9 +1257,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "updatedAt",
@@ -1421,9 +1273,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "userId",
@@ -1439,9 +1289,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -1451,9 +1299,7 @@
           "kind": "OBJECT",
           "name": "NotificationConnection",
           "description": "The connection type for Notification.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -1470,9 +1316,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "nodes",
@@ -1488,9 +1332,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "pageInfo",
@@ -1506,9 +1348,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -1518,9 +1358,7 @@
           "kind": "OBJECT",
           "name": "NotificationEdge",
           "description": "An edge in a connection.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -1537,9 +1375,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "node",
@@ -1551,9 +1387,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -1563,9 +1397,7 @@
           "kind": "OBJECT",
           "name": "Order",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -1582,9 +1414,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "guestEmail",
@@ -1596,9 +1426,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "id",
@@ -1614,9 +1442,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "status",
@@ -1632,9 +1458,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripeCheckoutSessionLineItems",
@@ -1658,9 +1482,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripePaymentIntentId",
@@ -1676,9 +1498,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "updatedAt",
@@ -1694,9 +1514,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "user",
@@ -1708,9 +1526,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -1720,9 +1536,7 @@
           "kind": "OBJECT",
           "name": "OrderLineItem",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -1739,9 +1553,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "quantity",
@@ -1757,9 +1569,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -1769,9 +1579,7 @@
           "kind": "OBJECT",
           "name": "OrderMessage",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -1784,9 +1592,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "createdAt",
@@ -1802,9 +1608,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "id",
@@ -1820,9 +1624,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "orderId",
@@ -1838,9 +1640,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "updatedAt",
@@ -1856,9 +1656,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "userId",
@@ -1874,9 +1672,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "userIsAdmin",
@@ -1892,9 +1688,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -2086,9 +1880,7 @@
           "kind": "OBJECT",
           "name": "PageInfo",
           "description": "Information about pagination in a connection.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -2101,9 +1893,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "hasNextPage",
@@ -2119,9 +1909,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "hasPreviousPage",
@@ -2137,9 +1925,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "startCursor",
@@ -2151,9 +1937,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -2163,9 +1947,7 @@
           "kind": "OBJECT",
           "name": "Price",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -2182,9 +1964,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripeObject",
@@ -2200,9 +1980,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "unitAmount",
@@ -2218,9 +1996,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -2230,9 +2006,7 @@
           "kind": "OBJECT",
           "name": "Product",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -2249,9 +2023,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "attributes",
@@ -2271,9 +2043,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "created",
@@ -2289,9 +2059,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "defaultPrice",
@@ -2307,9 +2075,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "description",
@@ -2325,9 +2091,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "id",
@@ -2343,9 +2107,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "images",
@@ -2365,9 +2127,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "livemode",
@@ -2383,9 +2143,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "marketingFeatures",
@@ -2401,9 +2159,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "metadata",
@@ -2419,9 +2175,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "name",
@@ -2437,9 +2191,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "packageDimensions",
@@ -2451,9 +2203,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "shippable",
@@ -2465,9 +2215,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "statementDescriptor",
@@ -2479,9 +2227,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripeObject",
@@ -2497,9 +2243,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "taxCode",
@@ -2515,9 +2259,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "type",
@@ -2533,9 +2275,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "unitLabel",
@@ -2547,9 +2287,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "updated",
@@ -2565,9 +2303,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "url",
@@ -2579,9 +2315,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -2591,9 +2325,7 @@
           "kind": "OBJECT",
           "name": "ProductListObject",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -2614,9 +2346,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "hasMore",
@@ -2632,9 +2362,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripeObject",
@@ -2650,9 +2378,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "url",
@@ -2668,9 +2394,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -2680,9 +2404,7 @@
           "kind": "OBJECT",
           "name": "Query",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -2695,9 +2417,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "currentUserNotifications",
@@ -2784,16 +2504,12 @@
               "deprecationReason": null,
               "args": [
                 {
-                  "name": "completed",
+                  "name": "incomplete",
                   "description": null,
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Boolean",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
                   },
                   "defaultValue": null,
                   "isDeprecated": false,
@@ -2844,9 +2560,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "order",
@@ -2936,9 +2650,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "retrieveProduct",
@@ -3016,9 +2728,7 @@
           "kind": "OBJECT",
           "name": "SetOrderStatusPayload",
           "description": "Autogenerated return type of SetOrderStatus.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -3031,9 +2741,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "order",
@@ -3049,9 +2757,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -3110,9 +2816,7 @@
           "kind": "OBJECT",
           "name": "StripeCheckoutSessionCreatePayload",
           "description": "Autogenerated return type of StripeCheckoutSessionCreate.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -3125,9 +2829,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "errors",
@@ -3151,9 +2853,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripeCheckoutSession",
@@ -3165,9 +2865,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -3212,9 +2910,7 @@
           "kind": "OBJECT",
           "name": "Subscription",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -3227,9 +2923,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "orderMessageReceived",
@@ -3268,9 +2962,7 @@
           "kind": "OBJECT",
           "name": "TotalDetails",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -3287,9 +2979,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "amountShipping",
@@ -3305,9 +2995,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "amountTax",
@@ -3323,9 +3011,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -3335,9 +3021,7 @@
           "kind": "OBJECT",
           "name": "User",
           "description": null,
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -3354,9 +3038,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "createdAt",
@@ -3372,9 +3054,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "email",
@@ -3390,9 +3070,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "id",
@@ -3408,9 +3086,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "stripeCustomerId",
@@ -3422,9 +3098,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "updatedAt",
@@ -3440,9 +3114,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -3452,9 +3124,7 @@
           "kind": "OBJECT",
           "name": "__Directive",
           "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -3504,9 +3174,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "isRepeatable",
@@ -3518,9 +3186,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "locations",
@@ -3544,9 +3210,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "name",
@@ -3562,9 +3226,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "onField",
@@ -3580,9 +3242,7 @@
               },
               "isDeprecated": true,
               "deprecationReason": "Use `locations`.",
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "onFragment",
@@ -3598,9 +3258,7 @@
               },
               "isDeprecated": true,
               "deprecationReason": "Use `locations`.",
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "onOperation",
@@ -3616,9 +3274,7 @@
               },
               "isDeprecated": true,
               "deprecationReason": "Use `locations`.",
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -3753,9 +3409,7 @@
           "kind": "OBJECT",
           "name": "__EnumValue",
           "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -3768,9 +3422,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "description",
@@ -3782,9 +3434,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "isDeprecated",
@@ -3800,9 +3450,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "name",
@@ -3818,9 +3466,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -3830,9 +3476,7 @@
           "kind": "OBJECT",
           "name": "__Field",
           "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -3882,9 +3526,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "description",
@@ -3896,9 +3538,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "isDeprecated",
@@ -3914,9 +3554,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "name",
@@ -3932,9 +3570,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "type",
@@ -3950,9 +3586,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -3962,9 +3596,7 @@
           "kind": "OBJECT",
           "name": "__InputValue",
           "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -3977,9 +3609,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "deprecationReason",
@@ -3991,9 +3621,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "description",
@@ -4005,9 +3633,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "isDeprecated",
@@ -4023,9 +3649,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "name",
@@ -4041,9 +3665,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "type",
@@ -4059,9 +3681,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -4071,9 +3691,7 @@
           "kind": "OBJECT",
           "name": "__Schema",
           "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -4086,9 +3704,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "directives",
@@ -4112,9 +3728,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "mutationType",
@@ -4126,9 +3740,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "queryType",
@@ -4144,9 +3756,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "subscriptionType",
@@ -4158,9 +3768,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "types",
@@ -4184,9 +3792,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -4196,9 +3802,7 @@
           "kind": "OBJECT",
           "name": "__Type",
           "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
-          "interfaces": [
-
-          ],
+          "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
@@ -4211,9 +3815,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "enumValues",
@@ -4332,9 +3934,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "isOneOf",
@@ -4350,9 +3950,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "kind",
@@ -4368,9 +3966,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "name",
@@ -4382,9 +3978,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "ofType",
@@ -4396,9 +3990,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "possibleTypes",
@@ -4418,9 +4010,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             },
             {
               "name": "specifiedByURL",
@@ -4432,9 +4022,7 @@
               },
               "isDeprecated": false,
               "deprecationReason": null,
-              "args": [
-
-              ]
+              "args": []
             }
           ],
           "inputFields": null,
@@ -4558,9 +4146,7 @@
           "locations": [
             "INPUT_OBJECT"
           ],
-          "args": [
-
-          ]
+          "args": []
         },
         {
           "name": "skip",

--- a/app/javascript/graphql/schema.json
+++ b/app/javascript/graphql/schema.json
@@ -1540,6 +1540,18 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "imageUrl",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "name",
               "description": null,
               "type": {

--- a/app/javascript/graphql/schema.json
+++ b/app/javascript/graphql/schema.json
@@ -1401,6 +1401,22 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "amountTotal",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "completedAt",
               "description": null,
               "type": {
@@ -1585,6 +1601,22 @@
             },
             {
               "name": "quantity",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "unitAmount",
               "description": null,
               "type": {
                 "kind": "NON_NULL",

--- a/app/javascript/graphql/types.ts
+++ b/app/javascript/graphql/types.ts
@@ -201,6 +201,7 @@ export type NotificationEdge = {
 
 export type Order = {
   __typename?: 'Order';
+  completedAt?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['String']['output'];
   guestEmail?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
@@ -488,7 +489,7 @@ export type FetchCurrentUserOrdersQueryVariables = Exact<{
 }>;
 
 
-export type FetchCurrentUserOrdersQuery = { __typename?: 'Query', currentUserOrders?: Array<{ __typename?: 'Order', id: string, createdAt: string, guestEmail?: string | null, updatedAt: string, status: OrderStatus, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', name: string, quantity: number, imageUrl: string }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
+export type FetchCurrentUserOrdersQuery = { __typename?: 'Query', currentUserOrders?: Array<{ __typename?: 'Order', id: string, createdAt: string, guestEmail?: string | null, updatedAt: string, status: OrderStatus, completedAt?: string | null, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', name: string, quantity: number, imageUrl: string }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
 
 export type OrderMessageReceivedSubscriptionVariables = Exact<{
   orderId: Scalars['ID']['input'];
@@ -948,6 +949,7 @@ export const FetchCurrentUserOrdersDocument = gql`
     guestEmail
     updatedAt
     status
+    completedAt
     stripeCheckoutSessionLineItems {
       name
       quantity

--- a/app/javascript/graphql/types.ts
+++ b/app/javascript/graphql/types.ts
@@ -333,7 +333,7 @@ export type QueryCurrentUserNotificationsArgs = {
 
 
 export type QueryCurrentUserOrdersArgs = {
-  completed: Scalars['Boolean']['input'];
+  incomplete?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
@@ -483,7 +483,7 @@ export type CreateOrderMessageMutationVariables = Exact<{
 export type CreateOrderMessageMutation = { __typename?: 'Mutation', createOrderMessage?: { __typename?: 'CreateOrderMessagePayload', orderMessage?: { __typename?: 'OrderMessage', id: string, userIsAdmin: boolean, userId: string, createdAt: any, body?: string | null } | null } | null };
 
 export type FetchCurrentUserOrdersQueryVariables = Exact<{
-  completed: Scalars['Boolean']['input'];
+  incomplete?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 
@@ -940,8 +940,8 @@ export type CreateOrderMessageMutationHookResult = ReturnType<typeof useCreateOr
 export type CreateOrderMessageMutationResult = Apollo.MutationResult<CreateOrderMessageMutation>;
 export type CreateOrderMessageMutationOptions = Apollo.BaseMutationOptions<CreateOrderMessageMutation, CreateOrderMessageMutationVariables>;
 export const FetchCurrentUserOrdersDocument = gql`
-    query FetchCurrentUserOrders($completed: Boolean!) {
-  currentUserOrders(completed: $completed) {
+    query FetchCurrentUserOrders($incomplete: Boolean) {
+  currentUserOrders(incomplete: $incomplete) {
     id
     status
     stripeCheckoutSessionLineItems {
@@ -969,11 +969,11 @@ export const FetchCurrentUserOrdersDocument = gql`
  * @example
  * const { data, loading, error } = useFetchCurrentUserOrdersQuery({
  *   variables: {
- *      completed: // value for 'completed'
+ *      incomplete: // value for 'incomplete'
  *   },
  * });
  */
-export function useFetchCurrentUserOrdersQuery(baseOptions: Apollo.QueryHookOptions<FetchCurrentUserOrdersQuery, FetchCurrentUserOrdersQueryVariables> & ({ variables: FetchCurrentUserOrdersQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+export function useFetchCurrentUserOrdersQuery(baseOptions?: Apollo.QueryHookOptions<FetchCurrentUserOrdersQuery, FetchCurrentUserOrdersQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
         return Apollo.useQuery<FetchCurrentUserOrdersQuery, FetchCurrentUserOrdersQueryVariables>(FetchCurrentUserOrdersDocument, options);
       }

--- a/app/javascript/graphql/types.ts
+++ b/app/javascript/graphql/types.ts
@@ -213,7 +213,7 @@ export type Order = {
 
 export type OrderLineItem = {
   __typename?: 'OrderLineItem';
-  imageUrl?: Maybe<Scalars['String']['output']>;
+  imageUrl: Scalars['String']['output'];
   name: Scalars['String']['output'];
   quantity: Scalars['Int']['output'];
 };
@@ -488,7 +488,7 @@ export type FetchCurrentUserOrdersQueryVariables = Exact<{
 }>;
 
 
-export type FetchCurrentUserOrdersQuery = { __typename?: 'Query', currentUserOrders?: Array<{ __typename?: 'Order', id: string, createdAt: string, guestEmail?: string | null, updatedAt: string, status: OrderStatus, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', name: string, quantity: number }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
+export type FetchCurrentUserOrdersQuery = { __typename?: 'Query', currentUserOrders?: Array<{ __typename?: 'Order', id: string, createdAt: string, guestEmail?: string | null, updatedAt: string, status: OrderStatus, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', name: string, quantity: number, imageUrl: string }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
 
 export type OrderMessageReceivedSubscriptionVariables = Exact<{
   orderId: Scalars['ID']['input'];
@@ -951,6 +951,7 @@ export const FetchCurrentUserOrdersDocument = gql`
     stripeCheckoutSessionLineItems {
       name
       quantity
+      imageUrl
     }
     user {
       id

--- a/app/javascript/graphql/types.ts
+++ b/app/javascript/graphql/types.ts
@@ -213,6 +213,7 @@ export type Order = {
 
 export type OrderLineItem = {
   __typename?: 'OrderLineItem';
+  imageUrl?: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
   quantity: Scalars['Int']['output'];
 };
@@ -487,7 +488,7 @@ export type FetchCurrentUserOrdersQueryVariables = Exact<{
 }>;
 
 
-export type FetchCurrentUserOrdersQuery = { __typename?: 'Query', currentUserOrders?: Array<{ __typename?: 'Order', id: string, status: OrderStatus, guestEmail?: string | null, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', name: string, quantity: number }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
+export type FetchCurrentUserOrdersQuery = { __typename?: 'Query', currentUserOrders?: Array<{ __typename?: 'Order', id: string, createdAt: string, guestEmail?: string | null, updatedAt: string, status: OrderStatus, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', name: string, quantity: number }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
 
 export type OrderMessageReceivedSubscriptionVariables = Exact<{
   orderId: Scalars['ID']['input'];
@@ -943,6 +944,9 @@ export const FetchCurrentUserOrdersDocument = gql`
     query FetchCurrentUserOrders($incomplete: Boolean) {
   currentUserOrders(incomplete: $incomplete) {
     id
+    createdAt
+    guestEmail
+    updatedAt
     status
     stripeCheckoutSessionLineItems {
       name
@@ -952,7 +956,6 @@ export const FetchCurrentUserOrdersDocument = gql`
       id
       email
     }
-    guestEmail
   }
 }
     `;

--- a/app/javascript/graphql/types.ts
+++ b/app/javascript/graphql/types.ts
@@ -201,6 +201,7 @@ export type NotificationEdge = {
 
 export type Order = {
   __typename?: 'Order';
+  amountTotal: Scalars['Int']['output'];
   completedAt?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['String']['output'];
   guestEmail?: Maybe<Scalars['String']['output']>;
@@ -217,6 +218,7 @@ export type OrderLineItem = {
   imageUrl: Scalars['String']['output'];
   name: Scalars['String']['output'];
   quantity: Scalars['Int']['output'];
+  unitAmount: Scalars['Int']['output'];
 };
 
 export type OrderMessage = {
@@ -489,7 +491,7 @@ export type FetchCurrentUserOrdersQueryVariables = Exact<{
 }>;
 
 
-export type FetchCurrentUserOrdersQuery = { __typename?: 'Query', currentUserOrders?: Array<{ __typename?: 'Order', id: string, createdAt: string, guestEmail?: string | null, updatedAt: string, status: OrderStatus, completedAt?: string | null, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', name: string, quantity: number, imageUrl: string }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
+export type FetchCurrentUserOrdersQuery = { __typename?: 'Query', currentUserOrders?: Array<{ __typename?: 'Order', id: string, amountTotal: number, createdAt: string, guestEmail?: string | null, updatedAt: string, status: OrderStatus, completedAt?: string | null, stripeCheckoutSessionLineItems: Array<{ __typename?: 'OrderLineItem', imageUrl: string, name: string, quantity: number, unitAmount: number }>, user?: { __typename?: 'User', id: string, email: string } | null }> | null };
 
 export type OrderMessageReceivedSubscriptionVariables = Exact<{
   orderId: Scalars['ID']['input'];
@@ -945,15 +947,17 @@ export const FetchCurrentUserOrdersDocument = gql`
     query FetchCurrentUserOrders($incomplete: Boolean) {
   currentUserOrders(incomplete: $incomplete) {
     id
+    amountTotal
     createdAt
     guestEmail
     updatedAt
     status
     completedAt
     stripeCheckoutSessionLineItems {
+      imageUrl
       name
       quantity
-      imageUrl
+      unitAmount
     }
     user {
       id

--- a/app/javascript/routes/index.tsx
+++ b/app/javascript/routes/index.tsx
@@ -16,6 +16,7 @@ import { BrowserRouter, Routes, Route } from "react-router";
 import AdminDashboardOrderChats from "components/admin/dashboard/orderChats/AdminDashboardOrderChats";
 import { ErrorBoundary } from "react-error-boundary";
 import AdminRoute from "components/protRoute/AdminRoute";
+import MyOrders from "components/myOrders/MyOrders";
 
 const DefaultError = () => {
   return (
@@ -50,6 +51,7 @@ const AppRoute = () => {
           <Route path="signup" element={<Signup />} />
           <Route path="login" element={<Login />} />
           <Route path="success" element={<OrderSuccess />} />
+          <Route path="my_orders" element={<MyOrders />} />
           <Route path="admin" element={<AdminRoute />}>
             <Route path="dashboard" element={<AdminDashboard />}>
               <Route index element={<AdminDashboardIndex />} />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resource :session, only: [ :new ]
-      resources :users, only: [ :create ] 
+      resources :users, only: [ :create ]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,10 +28,12 @@ Rails.application.routes.draw do
   get "order", to: "order#index"
   get "success", to: "order#success"
 
+  get "my_orders", to: "orders#index"
+
   namespace :api do
     namespace :v1 do
       resource :session, only: [ :new ]
-      resources :users, only: [ :create ]
+      resources :users, only: [ :create ] 
     end
   end
 

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,9 +1,24 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 1) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "solid_cable_messages", force: :cascade do |t|
-    t.binary "channel", limit: 1024, null: false
-    t.binary "payload", limit: 536870912, null: false
+    t.binary "channel", null: false
+    t.binary "payload", null: false
     t.datetime "created_at", null: false
-    t.integer "channel_hash", limit: 8, null: false
+    t.bigint "channel_hash", null: false
     t.index ["channel"], name: "index_solid_cable_messages_on_channel"
     t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
     t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"

--- a/db/migrate/20241207011311_add_completed_at_to_orders.rb
+++ b/db/migrate/20241207011311_add_completed_at_to_orders.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtToOrders < ActiveRecord::Migration[8.0]
+  def change
+    add_column :orders, :completed_at, :datetime
+  end
+end

--- a/db/migrate/20241207040021_add_total_amount_to_orders.rb
+++ b/db/migrate/20241207040021_add_total_amount_to_orders.rb
@@ -1,0 +1,5 @@
+class AddTotalAmountToOrders < ActiveRecord::Migration[8.0]
+  def change
+    add_column :orders, :amount_total, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_07_011311) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_07_040021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -42,6 +42,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_07_011311) do
     t.json "stripe_checkout_session_line_items"
     t.text "guest_email"
     t.datetime "completed_at"
+    t.integer "amount_total"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_21_065347) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_07_011311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -41,6 +41,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_21_065347) do
     t.datetime "updated_at", null: false
     t.json "stripe_checkout_session_line_items"
     t.text "guest_email"
+    t.datetime "completed_at"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/lib/tasks/add_image_url_line_items.rake
+++ b/lib/tasks/add_image_url_line_items.rake
@@ -1,0 +1,27 @@
+require "rake/task"
+
+
+task :add_image_url_line_items do
+    Rake::Task["environment"].invoke
+    # image_url will be a part of an order stripe_checkout_session_line_items
+
+    # first, find all orders
+    orders = Order.all
+
+    # then iterate through them all and recreate their line items
+
+    orders.in_batches of: 10 do |batch|
+        batch.each do |order|
+            stripe_checkout_session = Stripe::Checkout::Session.list payment_intent: order.stripe_payment_intent_id
+            checkout_line_items = Stripe::Checkout::Session.list_line_items stripe_checkout_session.first.id, expand: [ "data.price.product" ]
+
+            stripe_checkout_session_line_items = checkout_line_items.map do |item|
+                { name: item.description,
+                quantity: item.quantity,
+                image_url: item.price.product.images.first }
+            end
+
+            order.update(stripe_checkout_session_line_items: stripe_checkout_session_line_items)
+        end
+    end
+end

--- a/lib/tasks/set_completed_at.rake
+++ b/lib/tasks/set_completed_at.rake
@@ -1,0 +1,13 @@
+require "rake/task"
+
+task :set_completed_at do
+    Rake::Task["environment"].invoke
+
+    # find any completed orders
+    # set completed_at equal to updated_at
+    Order.completed.in_batches of: 10 do |batch|
+        batch.each do |order|
+            order.update(completed_at: order.updated_at)
+        end
+    end
+end

--- a/lib/tasks/update_line_items.rake
+++ b/lib/tasks/update_line_items.rake
@@ -1,7 +1,7 @@
 require "rake/task"
 
 
-task :add_image_url_line_items do
+task :update_line_items do
     Rake::Task["environment"].invoke
     # image_url will be a part of an order stripe_checkout_session_line_items
 
@@ -16,12 +16,18 @@ task :add_image_url_line_items do
             checkout_line_items = Stripe::Checkout::Session.list_line_items stripe_checkout_session.first.id, expand: [ "data.price.product" ]
 
             stripe_checkout_session_line_items = checkout_line_items.map do |item|
-                { name: item.description,
-                quantity: item.quantity,
-                image_url: item.price.product.images.first }
+                {
+                    name: item.description,
+                    quantity: item.quantity,
+                    image_url: item.price.product.images.first,
+                    unit_amount: item.amount_total
+                }
             end
 
-            order.update(stripe_checkout_session_line_items: stripe_checkout_session_line_items)
+            order.update(
+                amount_total: stripe_checkout_session.first.amount_total,
+                stripe_checkout_session_line_items: stripe_checkout_session_line_items
+            )
         end
     end
 end

--- a/spec/cassettes/event_payment_intent_succeeded_checkout.yml
+++ b/spec/cassettes/event_payment_intent_succeeded_checkout.yml
@@ -8,11 +8,11 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/13.1.1
+      - Stripe/v1 RubyBindings/13.2.0
       Authorization:
       - "<BEARER_TOKEN>"
       Stripe-Version:
-      - 2024-10-28.acacia
+      - 2024-11-20.acacia
       X-Stripe-Client-User-Agent:
       - "<X_STRIPE_CLIENT_USER_AGENT>"
       Accept-Encoding:
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 15 Nov 2024 04:03:15 GMT
+      - Fri, 06 Dec 2024 23:39:47 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -48,9 +48,9 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fcheckout%2Fsessions; block-all-mixed-content;
-        default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri /csp-violation
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Report-To:
@@ -58,9 +58,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_ywHTPPEp9bPlIr
+      - req_AA2nriDnCh4sgH
       Stripe-Version:
-      - 2024-10-28.acacia
+      - 2024-11-20.acacia
       Vary:
       - Origin
       X-Content-Type-Options:
@@ -70,7 +70,7 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - A
+      - AB
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
@@ -197,22 +197,22 @@ http_interactions:
           "has_more": false,
           "url": "/v1/checkout/sessions"
         }
-  recorded_at: Fri, 15 Nov 2024 04:03:15 GMT
+  recorded_at: Fri, 06 Dec 2024 23:39:47 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a1BBn4RW1sExgdMOA3yk7xvFVn2XGfONbOZsy0h6Up4CROhQKSYxcLJ49U/line_items
+    uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a1BBn4RW1sExgdMOA3yk7xvFVn2XGfONbOZsy0h6Up4CROhQKSYxcLJ49U/line_items?expand%5B%5D=data.price.product
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Stripe/v1 RubyBindings/13.1.1
+      - Stripe/v1 RubyBindings/13.2.0
       Authorization:
       - "<BEARER_TOKEN>"
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_ywHTPPEp9bPlIr","request_duration_ms":284}}'
+      - '{"last_request_metrics":{"request_id":"req_AA2nriDnCh4sgH","request_duration_ms":280}}'
       Stripe-Version:
-      - 2024-10-28.acacia
+      - 2024-11-20.acacia
       X-Stripe-Client-User-Agent:
       - "<X_STRIPE_CLIENT_USER_AGENT>"
       Accept-Encoding:
@@ -227,11 +227,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 15 Nov 2024 04:03:15 GMT
+      - Fri, 06 Dec 2024 23:39:47 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1089'
+      - '1936'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -248,10 +248,9 @@ http_interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Security-Policy:
-      - report-uri https://q.stripe.com/csp-report?p=v1%2Fcheckout%2Fsessions%2F%3Asession%2Fline_items;
-        block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action
-        'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample';
-        style-src 'self'
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
+        report-uri /csp-violation
       Cross-Origin-Opener-Policy-Report-Only:
       - same-origin; report-to="coop"
       Report-To:
@@ -259,9 +258,9 @@ http_interactions:
       Reporting-Endpoints:
       - coop="https://q.stripe.com/coop-report"
       Request-Id:
-      - req_U2FRXKGgRgv1oT
+      - req_4LC6AtWQGA46yv
       Stripe-Version:
-      - 2024-10-28.acacia
+      - 2024-11-20.acacia
       Vary:
       - Origin
       X-Content-Type-Options:
@@ -271,7 +270,7 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - A
+      - AB
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
@@ -301,7 +300,30 @@ http_interactions:
                 "lookup_key": null,
                 "metadata": {},
                 "nickname": null,
-                "product": "prod_R8KkVOibvpRPlc",
+                "product": {
+                  "id": "prod_R8KkVOibvpRPlc",
+                  "object": "product",
+                  "active": true,
+                  "attributes": [],
+                  "created": 1730403020,
+                  "default_price": "price_1QG44XElA4InVgv8dOnqfhyu",
+                  "description": "Blended mixed berries, filtered water",
+                  "images": [
+                    "https://files.stripe.com/links/MDB8YWNjdF8xUUczb3lFbEE0SW5WZ3Y4fGZsX3Rlc3Rfeml6NXpDODBvV2JFZUtvNFY2THVXdHpU00nQNlEhQt"
+                  ],
+                  "livemode": false,
+                  "marketing_features": [],
+                  "metadata": {},
+                  "name": "Mixed Berry Smoothie (Water base)",
+                  "package_dimensions": null,
+                  "shippable": null,
+                  "statement_descriptor": null,
+                  "tax_code": "txcd_20030000",
+                  "type": "service",
+                  "unit_label": null,
+                  "updated": 1733198430,
+                  "url": null
+                },
                 "recurring": null,
                 "tax_behavior": "unspecified",
                 "tiers_mode": null,
@@ -316,5 +338,5 @@ http_interactions:
           "has_more": false,
           "url": "/v1/checkout/sessions/cs_test_a1BBn4RW1sExgdMOA3yk7xvFVn2XGfONbOZsy0h6Up4CROhQKSYxcLJ49U/line_items"
         }
-  recorded_at: Fri, 15 Nov 2024 04:03:15 GMT
+  recorded_at: Fri, 06 Dec 2024 23:39:48 GMT
 recorded_with: VCR 6.3.1

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,11 +1,23 @@
 FactoryBot.define do
   factory :order do
     trait :with_line_items do
+      completed_at { nil }
+      amount_total { 600 }
       stripe_payment_intent_id  { "pi_12345" }
       stripe_checkout_session_line_items {
         [
-          { "name": "Mega Burrito", "quantity": 1 },
-          { "name": "Beeborito", "quantity": 2 }
+          {
+            "name": "Mega Burrito",
+            "quantity": 1,
+            "image_url": "www.someimage.com",
+            "unit_amount": 300
+          },
+          {
+            "name": "Beeborito",
+            "quantity": 2,
+            "image_url": "www.someimage.com",
+            "unit_amount": 300
+          }
         ]
       }
     end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -28,6 +28,13 @@ FactoryBot.define do
       end
     end
 
+
+    trait :cancelled do
+      after(:create) do |order|
+        order.cancelled!
+      end
+    end
+
     trait :with_order_messages do
       after(:create) do |order|
         order.order_messages.push create(:order_message, order: order, user: order.user)

--- a/spec/features/my_orders_spec.rb
+++ b/spec/features/my_orders_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "My Orders Features Spec" do
+    let!(:user) { create :user, :valid_user, :with_orders }
+
+    it "renders" do
+        feature_login_user user
+
+        visit my_orders_path
+        expect(page).to have_content "My Orders"
+        expect(page).to have_content "Order #"
+    end
+end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Notifications Features Spec", :perform_enqueued do
-    let(:user) { create :user, :valid_user, :with_orders }
-    let(:admin_user) { create :user, :valid_user, admin: true }
+    let!(:user) { create :user, :valid_user, :with_orders }
+    let!(:admin_user) { create :user, :valid_user, admin: true }
 
     it "sends a live notification to the admin user from the order user" do
         admin_session = "Admin session"
@@ -15,6 +15,7 @@ RSpec.describe "Notifications Features Spec", :perform_enqueued do
             visit order_chats_admin_dashboard_path
 
             chat_text = "Order ##{user.orders.first.id} Chat"
+
             expect(page).to have_content chat_text
         end
 

--- a/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
+++ b/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe "Set Order Status Mutation Spec" do
 
          it "sets the completed at column" do
             expect(order.completed_at).to be nil
-            
+
             perform_query order
 
             expect(order.completed_at).to be_present

--- a/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
+++ b/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
@@ -184,6 +184,8 @@ RSpec.describe "Set Order Status Mutation Spec" do
          end
 
          it "sets the completed at column" do
+            expect(order.completed_at).to be nil
+            
             perform_query order
 
             expect(order.completed_at).to be_present

--- a/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
+++ b/spec/requests/graphql/mutation/set_order_status_mutation_spec.rb
@@ -182,6 +182,12 @@ RSpec.describe "Set Order Status Mutation Spec" do
 
             perform_query order
          end
+
+         it "sets the completed at column" do
+            perform_query order
+
+            expect(order.completed_at).to be_present
+         end
       end
    end
 end

--- a/spec/requests/graphql/resolver/current_user_orders_resolver_spec.rb
+++ b/spec/requests/graphql/resolver/current_user_orders_resolver_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe("Order Resolver Spec") do
                 currentUserOrders(incomplete: $incomplete) {
                 id
                 status
+                amountTotal
                 stripeCheckoutSessionLineItems {
                     name
                     quantity
+                    unitAmount
+                    imageUrl
                 }
                 user {
                     id
@@ -60,7 +63,12 @@ RSpec.describe("Order Resolver Spec") do
 
                 expect(orders.first["id"].to_i).to eq order.id
                 expect(orders.first["status"]).to eq order.status
-                expect(orders.first["stripeCheckoutSessionLineItems"]).to eq order.stripe_checkout_session_line_items
+
+                expected_line_items = orders.first["stripeCheckoutSessionLineItems"].map do |item|
+                    item.transform_keys(&:underscore)
+                end
+
+                expect(expected_line_items).to eq order.stripe_checkout_session_line_items
                 expect(orders.first["user"]["id"].to_i).to eq order.user.id
                 expect(orders.first["user"]["email"]).to eq order.user.email_address
 

--- a/spec/requests/graphql/resolver/current_user_orders_resolver_spec.rb
+++ b/spec/requests/graphql/resolver/current_user_orders_resolver_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe("Order Resolver Spec") do
 
         context "when the incomplete argument is set to true" do
             let!(:order) { create :order, :with_line_items, :active, user_id: user.id }
+            let!(:distractor) { create :order, :with_line_items, :completed, user_id: user }
 
             it "returns the orders" do
                 params = { query: query, variables: { incomplete: true } }
@@ -56,11 +57,15 @@ RSpec.describe("Order Resolver Spec") do
 
                 orders = data["currentUserOrders"]
 
+
                 expect(orders.first["id"].to_i).to eq order.id
                 expect(orders.first["status"]).to eq order.status
                 expect(orders.first["stripeCheckoutSessionLineItems"]).to eq order.stripe_checkout_session_line_items
                 expect(orders.first["user"]["id"].to_i).to eq order.user.id
                 expect(orders.first["user"]["email"]).to eq order.user.email_address
+
+
+                expect(orders.pluck(:id).map(&:to_i)).not_to include distractor.id
             end
         end
 

--- a/spec/requests/graphql/resolver/current_user_orders_resolver_spec.rb
+++ b/spec/requests/graphql/resolver/current_user_orders_resolver_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe("Order Resolver Spec") do
     let(:query) {
         <<-GRAPHQL
-            query FetchCurrentUserOrders($completed: Boolean!) {
-                currentUserOrders(completed: $completed) {
+            query FetchCurrentUserOrders($incomplete: Boolean) {
+                currentUserOrders(incomplete: $incomplete) {
                 id
                 status
                 stripeCheckoutSessionLineItems {
@@ -28,12 +28,14 @@ RSpec.describe("Order Resolver Spec") do
     end
 
     context "when there is no current user" do
-        it "returns nil when current user is not present" do
-            params = { query: query, variables: { completed: false } }
+        it "raises an error" do
+            params = { query: query, variables: { incomplete: false } }
 
             perform_query params.to_json
 
-            expect(JSON.parse(response.body)["currentUserOrders"]).to be nil
+            message = JSON.parse(response.body)["errors"].first["message"]
+
+            expect(message).to eq "A current user is not logged in."
         end
     end
 
@@ -44,11 +46,11 @@ RSpec.describe("Order Resolver Spec") do
             login_user user
         end
 
-        context "when the user has completed orders" do
-            let!(:order) { create :order, :with_line_items, :completed, user_id: user.id }
+        context "when the incomplete argument is set to true" do
+            let!(:order) { create :order, :with_line_items, :active, user_id: user.id }
 
             it "returns the orders" do
-                params = { query: query, variables: { completed: true } }
+                params = { query: query, variables: { incomplete: true } }
 
                 data = perform_query params.to_json
 
@@ -62,21 +64,28 @@ RSpec.describe("Order Resolver Spec") do
             end
         end
 
-        context "when the user has incomplete orders" do
-            let!(:order) { create :order, :with_line_items, :active, user_id: user.id }
+        context "when no argument is passed to the query" do
+            let!(:current_user_orders) {
+                [
+                    create(:order, :with_line_items, user_id: user.id),
+                    create(:order, :with_line_items, :active, user_id: user.id),
+                    create(:order, :with_line_items, :in_transit, user_id: user.id),
+                    create(:order, :with_line_items, :completed, user_id: user.id),
+                    create(:order, :with_line_items, :cancelled, user_id: user.id)
+                ]
+            }
 
-            it "returns the orders" do
-                params = { query: query, variables: { completed: false } }
+            let!(:distractor) { create :order, :with_line_items, user: create(:user, :valid_user) }
+
+            it "returns all of the current user's orders" do
+                params = { query: query }
 
                 data = perform_query params.to_json
 
                 orders = data["currentUserOrders"]
 
-                expect(orders.first["id"].to_i).to eq order.id
-                expect(orders.first["status"]).to eq order.status
-                expect(orders.first["stripeCheckoutSessionLineItems"]).to eq order.stripe_checkout_session_line_items
-                expect(orders.first["user"]["id"].to_i).to eq order.user.id
-                expect(orders.first["user"]["email"]).to eq order.user.email_address
+                expect(orders.pluck("id").map(&:to_i)).to match_array(current_user_orders.pluck(:id))
+                expect(orders.pluck("id").map(&:to_i)).not_to include distractor.id
             end
         end
     end

--- a/spec/requests/graphql/resolver/order_resolver_spec.rb
+++ b/spec/requests/graphql/resolver/order_resolver_spec.rb
@@ -12,10 +12,13 @@ RSpec.describe("Order Resolver Spec") do
                     status
                     stripePaymentIntentId
                     createdAt
+                    amountTotal
                     updatedAt
                     stripeCheckoutSessionLineItems {
                         name
                         quantity
+                        unitAmount
+                        imageUrl
                     }
                     guestEmail
                 }
@@ -39,7 +42,9 @@ RSpec.describe("Order Resolver Spec") do
             expect(gql_order["stripePaymentIntentId"]).to eq order.stripe_payment_intent_id
             expect(gql_order["createdAt"]).to eq order.created_at.strftime "%Y-%m-%d"
             expect(gql_order["updatedAt"]).to eq order.updated_at.strftime "%Y-%m-%d"
-            expect(gql_order["stripeCheckoutSessionLineItems"]).to match_array(order.stripe_checkout_session_line_items)
+            expect(
+                gql_order["stripeCheckoutSessionLineItems"].map { |item| item.transform_keys(&:underscore) }
+            ).to match_array(order.stripe_checkout_session_line_items)
             expect(gql_order["guestEmail"]).to eq order.guest_email
         end
     end

--- a/spec/requests/graphql/resolver/orders_resolver_spec.rb
+++ b/spec/requests/graphql/resolver/orders_resolver_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe "Orders Resolver Spec" do
                 orders {
                     id
                     status
+                    amountTotal
                     stripeCheckoutSessionLineItems {
                         name
                         quantity
+                        imageUrl
+                        unitAmount
                     }
                     user {
                         id
@@ -34,7 +37,13 @@ RSpec.describe "Orders Resolver Spec" do
             .to match_array(orders.pluck(:user_id))
         expect(graphql_orders_response.map { |order| order["user"]["email"] })
             .to match_array(orders.map { |order| order.user.email_address })
-        expect(graphql_orders_response.map { |order| order["stripeCheckoutSessionLineItems"] })
+        expect(
+            graphql_orders_response.map do |order|
+                order["stripeCheckoutSessionLineItems"].map do |item|
+                    item.transform_keys(&:underscore)
+                end
+            end
+        )
             .to match_array(orders.map { |order| order.stripe_checkout_session_line_items })
 
         expect(graphql_orders_response.pluck("id").map(&:to_i)).to match_array orders.reverse.pluck(:id)

--- a/spec/requests/stripe/events_spec.rb
+++ b/spec/requests/stripe/events_spec.rb
@@ -107,8 +107,9 @@ RSpec.describe "Stripe::EventsController", type: :request do
 
         expect(order.stripe_payment_intent_id).to eq event["data"]["object"]["id"]
         expect(event["data"]["object"]["customer"]).to be_present
-        expect(order.stripe_checkout_session_line_items)
-          .to eq(order.stripe_checkout_session_line_items)
+
+        expected_line_items = { name: response_checkout_line_items[:data].first[:description], quantity: response_checkout_line_items[:data].first[:quantity], image_url: response_checkout_line_items[:data].first[:price][:product][:images].first }
+        expect(order.stripe_checkout_session_line_items.first.symbolize_keys).to eq expected_line_items
         expect(order.guest_email).to eq(response_checkout_session["data"].first["customer_details"]["email"])
       end
 
@@ -127,8 +128,8 @@ RSpec.describe "Stripe::EventsController", type: :request do
 
         expect(order.stripe_payment_intent_id).to eq event["data"]["object"]["id"]
         expect(event["data"]["object"]["customer"]).to be_present
-        expect(order.stripe_checkout_session_line_items)
-          .to eq(order.stripe_checkout_session_line_items)
+        expected_line_items = { name: response_checkout_line_items[:data].first[:description], quantity: response_checkout_line_items[:data].first[:quantity], image_url: response_checkout_line_items[:data].first[:price][:product][:images].first }
+        expect(order.stripe_checkout_session_line_items.first.symbolize_keys).to eq expected_line_items
 
         # Technically, the user email should equal that in the Stripe checkout
         # Due to the order of the mocking, it makes sense to ensure the order points to the created user

--- a/spec/requests/stripe/events_spec.rb
+++ b/spec/requests/stripe/events_spec.rb
@@ -108,8 +108,15 @@ RSpec.describe "Stripe::EventsController", type: :request do
         expect(order.stripe_payment_intent_id).to eq event["data"]["object"]["id"]
         expect(event["data"]["object"]["customer"]).to be_present
 
-        expected_line_items = { name: response_checkout_line_items[:data].first[:description], quantity: response_checkout_line_items[:data].first[:quantity], image_url: response_checkout_line_items[:data].first[:price][:product][:images].first }
+        expected_line_items = {
+          name: response_checkout_line_items[:data].first[:description],
+          quantity: response_checkout_line_items[:data].first[:quantity],
+          image_url: response_checkout_line_items[:data].first[:price][:product][:images].first,
+          unit_amount: response_checkout_line_items[:data].first[:amount_total]
+        }
+
         expect(order.stripe_checkout_session_line_items.first.symbolize_keys).to eq expected_line_items
+        expect(order.amount_total).to eq response_checkout_session.data.first.amount_total
         expect(order.guest_email).to eq(response_checkout_session["data"].first["customer_details"]["email"])
       end
 
@@ -128,12 +135,20 @@ RSpec.describe "Stripe::EventsController", type: :request do
 
         expect(order.stripe_payment_intent_id).to eq event["data"]["object"]["id"]
         expect(event["data"]["object"]["customer"]).to be_present
-        expected_line_items = { name: response_checkout_line_items[:data].first[:description], quantity: response_checkout_line_items[:data].first[:quantity], image_url: response_checkout_line_items[:data].first[:price][:product][:images].first }
+
+        expected_line_items = {
+          name: response_checkout_line_items[:data].first[:description],
+          quantity: response_checkout_line_items[:data].first[:quantity],
+          image_url: response_checkout_line_items[:data].first[:price][:product][:images].first,
+          unit_amount: response_checkout_line_items[:data].first[:amount_total]
+        }
+
         expect(order.stripe_checkout_session_line_items.first.symbolize_keys).to eq expected_line_items
 
         # Technically, the user email should equal that in the Stripe checkout
         # Due to the order of the mocking, it makes sense to ensure the order points to the created user
         # and the guest email is blank, because this ensures that the user created in this spec was assigned to the order
+        expect(order.amount_total).to eq response_checkout_session.data.first.amount_total
         expect(order.user).to eq user
         expect(order.guest_email).to be nil
       end


### PR DESCRIPTION
# IMPORTANT NOTE
**Run the `set_completed_at` rake task before the others!!** This will ensure that the `completed_at` is accurate when set to `updated_at`.

## Tasks to run to reconcile database
`bundle exec rake set_completed_at`
`bundle exec rake update_line_items`

# My Orders
- Allow user to view their order history by clicking "My Orders" from the User Account header dropdown
- add `completed_at` to the `orders` table
- add `image_url` and `unit_amount` to the `orders` `line_items` JSON column
- add `amount_total` to the `orders` table
- create rake tasks to update the existing `orders` `line_items` with the newly added information 
