### PR TITLE
Specify solid queue and cable versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,9 +40,9 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-gem "solid_queue", "~> 1.0"
+gem "solid_queue", "~> 1.1.0"
 
-gem "solid_cable", "~> 3.0"
+gem "solid_cable", "~> 3.0.4"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    solid_cable (3.0.3)
+    solid_cable (3.0.4)
       actioncable (>= 7.2)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -374,8 +374,8 @@ DEPENDENCIES
   rspec-rails (~> 7.1.0)
   rubocop-rails-omakase
   selenium-webdriver
-  solid_cable (~> 3.0)
-  solid_queue (~> 1.0)
+  solid_cable (~> 3.0.4)
+  solid_queue (~> 1.1.0)
   sprockets-rails
   stimulus-rails
   stripe


### PR DESCRIPTION
**Issue**: Reloading the page after editing any rails file would cause an infinite hang/stall that required a server restart .

**Solution**: Set the `solid_queue` version to `1.1.0` in the `Gemfile`

Apparently, there was a version mismatch after updating gems from a recent PR