### PR TITLE
Create <ImageLoader />

### DIFF
--- a/app/javascript/components/Order/orderItem/OrderItem.tsx
+++ b/app/javascript/components/Order/orderItem/OrderItem.tsx
@@ -1,3 +1,4 @@
+import ImageLoader from "components/imageLoader/ImageLoader";
 import { CartContext } from "context/CartProvider";
 import { NotificationsContext } from "context/NotificationsProvider";
 import { Price, Product, User } from "graphql/types";
@@ -43,7 +44,11 @@ const OrderItem: React.FC<{
         reset();
       })}
     >
-      <img src={imageUrl} className="cursor-pointer mb-2 w-[224px] h-[224px]" />
+      <ImageLoader
+        alt={name}
+        src={imageUrl}
+        additionalClassName="cursor-pointer mb-2 w-[224px] h-[224px]"
+      />
       <p className="font-bold text-lg mb-2 h-[60px]">{name}</p>
       <p className="mb-2 h-[60px]">{description}</p>
       <p className="mb-6">

--- a/app/javascript/components/imageLoader/ImageLoader.test.tsx
+++ b/app/javascript/components/imageLoader/ImageLoader.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { screen, render, fireEvent } from "@testing-library/react";
+import ImageLoader from "components/imageLoader/ImageLoader";
+
+describe("<ImageLoader />", () => {
+  it("hides the image until loaded", async () => {
+    const alt = "cool item";
+    const spinnerTestId = "loading-spinner";
+
+    render(<ImageLoader alt={alt} src="someImage.jpg" />);
+
+    expect(await screen.findByAltText(alt)).toBeInTheDocument();
+
+    // The image should initially have no opacity
+    expect(screen.getByAltText(alt)).toHaveClass("opacity-0");
+    expect(screen.getByTestId(spinnerTestId)).toHaveClass("block");
+
+    fireEvent.load(screen.getByAltText(alt));
+
+    expect(await screen.findByAltText(alt)).toHaveClass("opacity-100");
+    expect(screen.getByTestId(spinnerTestId)).toHaveClass("hidden");
+  });
+});

--- a/app/javascript/components/imageLoader/ImageLoader.tsx
+++ b/app/javascript/components/imageLoader/ImageLoader.tsx
@@ -1,0 +1,37 @@
+import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { useState } from "react";
+
+const ImageLoader: React.FC<{
+  src: string;
+  alt: string;
+  additionalClassName?: string;
+}> = ({ src, additionalClassName, alt }) => {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <div
+      className={`relative ${additionalClassName ? additionalClassName : ""}`}
+    >
+      <img
+        src={src}
+        alt={alt}
+        onLoad={() => setLoaded(true)}
+        className={`opacity-0 transition-opacity duration-1000 ${
+          loaded ? "opacity-100" : ""
+        } `}
+      />
+
+      <FontAwesomeIcon
+        icon={faSpinner}
+        data-testid="loading-spinner"
+        spin
+        className={`absolute inset-0 m-auto w-1/2 h-1/2 ${
+          loaded ? "hidden" : "block"
+        }`}
+      />
+    </div>
+  );
+};
+
+export default ImageLoader;

--- a/app/javascript/components/myOrders/MyOrders.tsx
+++ b/app/javascript/components/myOrders/MyOrders.tsx
@@ -1,5 +1,6 @@
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ImageLoader from "components/imageLoader/ImageLoader";
 import { useFetchCurrentUserOrdersQuery } from "graphql/types";
 import { startCase } from "lodash";
 import React from "react";
@@ -67,8 +68,9 @@ const MyOrders = () => {
                           zIndex: items.length - i,
                         }}
                       >
-                        <img
-                          className={`w-full h-full rounded-full `}
+                        <ImageLoader
+                          alt={item.name}
+                          additionalClassName={`w-full h-full rounded-full `}
                           src={item.imageUrl}
                         />
                       </div>

--- a/app/javascript/components/shoppingCart/ShoppingCart.tsx
+++ b/app/javascript/components/shoppingCart/ShoppingCart.tsx
@@ -5,11 +5,11 @@ import {
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ImageLoader from "components/imageLoader/ImageLoader";
 import { CartContext } from "context/CartProvider";
 import {
   Error,
   OrderPageInput,
-  StripeCheckoutSessionCreateInput,
   useStripeCheckoutSessionCreateMutation,
 } from "graphql/types";
 import React, { useContext, useEffect, useState } from "react";
@@ -128,7 +128,11 @@ const ShoppingCartItems = () => {
               key={stripePrice}
               className="grid grid-cols-[auto_1fr_auto] gap-x-4 items-center mb-6"
             >
-              <img className="w-16" src={itemInfo.imageUrl} />
+              <ImageLoader
+                alt={itemInfo.name}
+                additionalClassName="w-16"
+                src={itemInfo.imageUrl}
+              />
               <div>
                 <p className="font-bold">{itemInfo.name}</p>
                 <p className="text-sm">{itemInfo.description}</p>


### PR DESCRIPTION
- `<ImageLoader />` is used in place of standard `<img />` tags in order to render a loading spinner until the image has fully loaded, improving visual aesthetics